### PR TITLE
vtl.stats : fix vtl.stats.sum() and vtl.stats.prod()

### DIFF
--- a/stats/stats.v
+++ b/stats/stats.v
@@ -9,7 +9,7 @@ pub struct AxisData {
 
 // sum returns the sum of all elements of the given tensor
 pub fn sum<T>(t &vtl.Tensor<T>) T {
-	mut iter := t.iterator(data.axis)
+	mut iter := t.iterator()
 	mut acc := T(0)
 	for {
 		val, _ := iter.next() or { break }

--- a/stats/stats.v
+++ b/stats/stats.v
@@ -42,11 +42,19 @@ pub fn sum_axis_with_dims<T>(t &vtl.Tensor<T>, data AxisData) T {
 	return acc
 }
 
-// prod_axis returns the product of a given Tensor along a provided
-// axis
+// prod returns the product of all elements of the given tensor
 pub fn prod<T>(t &vtl.Tensor<T>) T {
-	mut iter := t.iterator(data.axis)
-	mut acc := T(0)
+
+	/*
+	If the tensor is empty, his product is zero
+	We are returning it right way otherwise it will be set to 1
+	*/
+	if t.size == 0{
+		return f64(0)
+	}
+
+	mut iter := t.iterator()
+	mut acc := T(1)
 	for {
 		val, _ := iter.next() or { break }
 		acc *= val

--- a/stats/stats_test.v
+++ b/stats/stats_test.v
@@ -251,6 +251,22 @@ fn test_range() {
 	assert o == f64(68.242)
 }
 
+fn test_sum() {
+	// Tests were also verified on Wolfram Alpha
+	mut data := vtl.from_1d([f64(10.0), f64(4.45), f64(5.9), f64(2.7)])
+	mut o := sum(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '23.05')
+	data = vtl.from_1d([f64(-3.0), f64(67.31), f64(4.4), f64(1.89)])
+	o = sum(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '70.6')
+	data = vtl.from_1d([f64(12.0), f64(7.88), f64(76.122), f64(54.83)])
+	o = sum(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '150.832')
+}
+
 fn test_passing_empty() {
 	data := vtl.from_1d([]f64{})
 	assert freq(data, 0) == 0
@@ -268,4 +284,5 @@ fn test_passing_empty() {
 	assert min(data) == f64(0)
 	assert max(data) == f64(0)
 	assert range(data) == f64(0)
+	assert sum(data) == f64(0)
 }

--- a/stats/stats_test.v
+++ b/stats/stats_test.v
@@ -267,6 +267,22 @@ fn test_sum() {
 	assert tst_res(o.str(), '150.832')
 }
 
+fn test_prod() {
+	// Tests were also verified on Wolfram Alpha
+	mut data := vtl.from_1d([f64(10.0), f64(4.45), f64(5.9), f64(2.7)])
+	mut o := prod(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '708.885')
+	data = vtl.from_1d([f64(-3.0), f64(67.31), f64(4.4), f64(1.89)])
+	o = prod(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '-1679.24988')
+	data = vtl.from_1d([f64(12.0), f64(7.88), f64(76.122), f64(54.83)])
+	o = prod(data)
+	// Some issue with precision comparison in f64 using == operator hence serializing to string
+	assert tst_res(o.str(), '394671.621226')
+}
+
 fn test_passing_empty() {
 	data := vtl.from_1d([]f64{})
 	assert freq(data, 0) == 0
@@ -285,4 +301,5 @@ fn test_passing_empty() {
 	assert max(data) == f64(0)
 	assert range(data) == f64(0)
 	assert sum(data) == f64(0)
+	assert prod(data) == f64(0)
 }


### PR DESCRIPTION
Hello, 

This PR fixes `vtl.stats.sum()` and `vtl.stats.prod()` functions which were not working (ie. compiling) at all, as described in #16.

- `Tensor.iterator()` in both of those functions don't take an `axis` arguments
- Made `acc` starts from 1 in `vtl.stats.prod()` to avoid product being always 0
- Made `vtl.stats.prod()` returning zeros if the `Tensor` given in argument is empty

I also added unit tests for those functions, which were lacking.