### PR TITLE
fix gate.cache() argument mismatch

### DIFF
--- a/nn/layers/maxpool.v
+++ b/nn/layers/maxpool.v
@@ -50,7 +50,7 @@ pub fn (layer &MaxPool2DLayer<T>) forward(mut input autograd.Variable<T>) ?&auto
 	if input.requires_grad {
 		gate := layers.maxpool2d_gate<T>(max_indices, layer.kernel, input.value.shape,
 			layer.padding, layer.stride)
-		gate.cache(mut result, input, layer.kernel, layer.padding, layer.stride)?
+		gate.cache(mut result, input, layer.kernel, layer.padding, ...layer.stride)?
 	}
 
 	return result


### PR DESCRIPTION
This PR fix gate.cache() argument mismatch.