### PR TITLE
fix(vulkan): add missing conv2d_forward_vulkan CPU stub

### DIFF
--- a/nn/layers/conv2d_vulkan_notd_vulkan.v
+++ b/nn/layers/conv2d_vulkan_notd_vulkan.v
@@ -1,0 +1,22 @@
+module layers
+
+// Stub for non-Vulkan builds — conv2d_forward_vulkan falls through to CPU.
+
+import vtl
+import vtl.nn.internal
+
+pub fn conv2d_forward_vulkan[T](
+	input       &vtl.Tensor[T],
+	weight      &vtl.Tensor[T],
+	bias        &vtl.Tensor[T],
+	kernel_size []int,
+	config      Conv2DConfig
+) !&vtl.Tensor[T] {
+	cfg := internal.Conv2DConfig{
+		padding:  config.padding
+		stride:   config.stride
+		dilation: config.dilation
+		groups:   config.groups
+	}
+	return internal.conv2d_forward[T](input, weight, bias, kernel_size, cfg)
+}


### PR DESCRIPTION
Adds the missing `conv2d_vulkan_notd_vulkan.v` stub so that `conv2d_forward_vulkan` compiles without `-d vulkan`, falling back to `internal.conv2d_forward`. Fixes a build regression introduced in Phase 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented 2D convolution forward operation with automatic CPU fallback for non-Vulkan environments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/70)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->