### PR TITLE
feat(vulkan): Phase 4 — GPU embedding lookup (EmbeddingLayerVulkan)

### DIFF
--- a/nn/layers/embedding_vulkan_d_vulkan.v
+++ b/nn/layers/embedding_vulkan_d_vulkan.v
@@ -1,0 +1,86 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+// embedding_forward_vulkan gathers rows from the weight matrix using GPU.
+// input: [batch, seq_len] integer indices (stored as T, cast to u32)
+// weight: [vocab_size, embed_dim] float32 embedding table
+// output: [batch, seq_len, embed_dim]
+pub fn embedding_forward_vulkan[T](input &vtl.Tensor[T], weight &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	$if T !is f32 {
+		// f64 not natively supported by GPU kernel — fall back to CPU
+		return embedding_forward_cpu[T](input, weight)
+	}
+	batch := input.shape[0]
+	seq_len := input.shape[1]
+	vocab_size := u32(weight.shape[0])
+	embed_dim := u32(weight.shape[1])
+	num_indices := u32(batch * seq_len)
+
+	mut dev := vulkan.new_device() or {
+		return embedding_forward_cpu[T](input, weight)
+	}
+	defer { dev.release() or {} }
+
+	// Upload flat indices as u32
+	mut idx_bytes := []u8{len: int(num_indices * 4)}
+	for i in 0 .. int(num_indices) {
+		b := i / seq_len
+		s := i % seq_len
+		val := u32(input.get([b, s]))
+		unsafe { *(&u32(&idx_bytes[i * 4])) = val }
+	}
+	mut idx_buf := dev.buffer(vulkan.DeviceSize(u64(num_indices) * 4))!
+	defer { idx_buf.release() }
+	idx_buf.load(idx_bytes)!
+
+	// Upload embedding table as f32
+	table_size := int(vocab_size * embed_dim)
+	mut table_bytes := []u8{len: table_size * 4}
+	for i in 0 .. table_size {
+		r := i / int(embed_dim)
+		c := i % int(embed_dim)
+		val := f32(weight.get([r, c]))
+		unsafe { *(&f32(&table_bytes[i * 4])) = val }
+	}
+	mut table_buf := dev.buffer(vulkan.DeviceSize(u64(table_size) * 4))!
+	defer { table_buf.release() }
+	table_buf.load(table_bytes)!
+
+	// Output buffer: [num_indices, embed_dim]
+	mut out_buf := dev.buffer(vulkan.DeviceSize(u64(num_indices * embed_dim) * 4))!
+	defer { out_buf.release() }
+
+	vulkan.embedding_gather(dev, out_buf, idx_buf, table_buf, num_indices, vocab_size, embed_dim)!
+
+	mut raw := []u8{len: int(num_indices * embed_dim * 4)}
+	out_buf.store(mut raw)!
+
+	mut result_data := []T{len: int(num_indices * embed_dim)}
+	for i in 0 .. result_data.len {
+		unsafe { result_data[i] = T(*(&f32(&raw[i * 4]))) }
+	}
+
+	mut t := vtl.from_1d[T](result_data, vtl.TensorData{})!
+	return t.reshape([batch, seq_len, int(embed_dim)])!
+}
+
+// embedding_forward_cpu is the pure-V fallback used for non-f32 types.
+fn embedding_forward_cpu[T](input &vtl.Tensor[T], weight &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	batch := input.shape[0]
+	seq_len := input.shape[1]
+	embed_dim := weight.shape[1]
+	mut output := vtl.zeros[T]([batch, seq_len, embed_dim])
+	for b in 0 .. batch {
+		for s in 0 .. seq_len {
+			idx := int(input.get([b, s]))
+			if idx >= 0 && idx < weight.shape[0] {
+				for d in 0 .. embed_dim {
+					output.set([b, s, d], weight.get([idx, d]))
+				}
+			}
+		}
+	}
+	return output
+}

--- a/nn/layers/embedding_vulkan_d_vulkan_test.v
+++ b/nn/layers/embedding_vulkan_d_vulkan_test.v
@@ -1,0 +1,68 @@
+module layers
+
+import vtl
+
+fn test_embedding_forward_vulkan_basic() {
+	// vocab_size=4, embed_dim=3
+	// weight rows: [0]=1,2,3  [1]=4,5,6  [2]=7,8,9  [3]=10,11,12
+	weight_data := [f32(1), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+	weight := vtl.from_1d[f32](weight_data, vtl.TensorData{})!.reshape([4, 3])!
+
+	// input: [1, 4] indices = [0, 2, 1, 3]
+	indices_data := [f32(0), 2, 1, 3]
+	indices := vtl.from_1d[f32](indices_data, vtl.TensorData{})!.reshape([1, 4])!
+
+	out := embedding_forward_vulkan[f32](indices, weight)!
+
+	assert out.shape == [1, 4, 3]
+
+	// row 0 → [1,2,3]
+	assert f32(out.get([0, 0, 0])) == f32(1)
+	assert f32(out.get([0, 0, 1])) == f32(2)
+	assert f32(out.get([0, 0, 2])) == f32(3)
+
+	// row 2 → [7,8,9]
+	assert f32(out.get([0, 1, 0])) == f32(7)
+	assert f32(out.get([0, 1, 1])) == f32(8)
+	assert f32(out.get([0, 1, 2])) == f32(9)
+
+	// row 1 → [4,5,6]
+	assert f32(out.get([0, 2, 0])) == f32(4)
+	assert f32(out.get([0, 2, 1])) == f32(5)
+	assert f32(out.get([0, 2, 2])) == f32(6)
+
+	// row 3 → [10,11,12]
+	assert f32(out.get([0, 3, 0])) == f32(10)
+	assert f32(out.get([0, 3, 1])) == f32(11)
+	assert f32(out.get([0, 3, 2])) == f32(12)
+}
+
+fn test_embedding_forward_vulkan_batch() {
+	// vocab_size=3, embed_dim=2, batch=2, seq_len=2
+	weight_data := [f32(1), 2, 3, 4, 5, 6]
+	weight := vtl.from_1d[f32](weight_data, vtl.TensorData{})!.reshape([3, 2])!
+
+	// indices: [[0,1],[2,0]]
+	indices_data := [f32(0), 1, 2, 0]
+	indices := vtl.from_1d[f32](indices_data, vtl.TensorData{})!.reshape([2, 2])!
+
+	out := embedding_forward_vulkan[f32](indices, weight)!
+
+	assert out.shape == [2, 2, 2]
+
+	// batch=0, seq=0: idx=0 → [1,2]
+	assert f32(out.get([0, 0, 0])) == f32(1)
+	assert f32(out.get([0, 0, 1])) == f32(2)
+
+	// batch=0, seq=1: idx=1 → [3,4]
+	assert f32(out.get([0, 1, 0])) == f32(3)
+	assert f32(out.get([0, 1, 1])) == f32(4)
+
+	// batch=1, seq=0: idx=2 → [5,6]
+	assert f32(out.get([1, 0, 0])) == f32(5)
+	assert f32(out.get([1, 0, 1])) == f32(6)
+
+	// batch=1, seq=1: idx=0 → [1,2]
+	assert f32(out.get([1, 1, 0])) == f32(1)
+	assert f32(out.get([1, 1, 1])) == f32(2)
+}

--- a/nn/layers/embedding_vulkan_notd_vulkan.v
+++ b/nn/layers/embedding_vulkan_notd_vulkan.v
@@ -1,0 +1,23 @@
+module layers
+
+// Stub for non-Vulkan builds — embedding_forward_vulkan falls through to CPU.
+
+import vtl
+
+pub fn embedding_forward_vulkan[T](input &vtl.Tensor[T], weight &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	batch := input.shape[0]
+	seq_len := input.shape[1]
+	embed_dim := weight.shape[1]
+	mut output := vtl.zeros[T]([batch, seq_len, embed_dim])
+	for b in 0 .. batch {
+		for s in 0 .. seq_len {
+			idx := int(input.get([b, s]))
+			if idx >= 0 && idx < weight.shape[0] {
+				for d in 0 .. embed_dim {
+					output.set([b, s, d], weight.get([idx, d]))
+				}
+			}
+		}
+	}
+	return output
+}


### PR DESCRIPTION
## Phase 4: GPU Embedding Gather

Adds GPU-accelerated token embedding lookup using VSL's `embedding_gather` SPIR-V kernel.

### What's new

- `embedding_forward_vulkan[T]` — GPU path for f32, CPU fallback for f64
- Input: `[batch, seq_len]` integer indices (stored as T, cast to u32)
- Weight: `[vocab_size, embed_dim]` embedding table
- Output: `[batch, seq_len, embed_dim]`

### Files
- `nn/layers/embedding_vulkan_d_vulkan.v` — GPU implementation
- `nn/layers/embedding_vulkan_notd_vulkan.v` — CPU stub for non-Vulkan builds
- `nn/layers/embedding_vulkan_d_vulkan_test.v` — tests (run only with `-d vulkan`)

### Tests
- Basic gather: vocab=4, dim=3, indices=[0,2,1,3]
- Batched gather: batch=2, seq=2, vocab=3, dim=2

**Dependencies**: VSL Phase 4 (`embedding_gather` kernel) ✅ available
**CI**: `v -d vulkan test vtl`