### PR TITLE
feat(nn/layers): add GELULayerVulkan and MaxPool2DLayerVulkan (Phases 5 & 7)

### DIFF
--- a/nn/layers/gelu_vulkan_d_vulkan.v
+++ b/nn/layers/gelu_vulkan_d_vulkan.v
@@ -1,0 +1,35 @@
+module layers
+
+import storage
+import vtl
+import vsl.vulkan
+
+// gelu_forward_vulkan computes GELU activation on GPU (f32 native).
+// Uses tanh approximation: 0.5*x*(1+tanh(sqrt(2/pi)*(x+0.044715*x^3)))
+// f64 falls back to CPU.
+pub fn gelu_forward_vulkan[T](x &vtl.Tensor[T], params storage.VulkanStorageParams) !&vtl.Tensor[T] {
+	n := x.size()
+	$if T is f32 {
+		vk := x.vulkan(params)!
+		defer {
+			vk.release() or {}
+		}
+		dev := vk.data.data.device
+		mut out_buf := dev.buffer(vulkan.DeviceSize(u64(n) * 4))!
+		defer {
+			out_buf.release()
+		}
+		vulkan.gelu(dev, out_buf, vk.data.data, u32(n))!
+		mut raw := []u8{len: n * 4}
+		raw = out_buf.store(mut raw)!
+		mut vals := []T{len: n}
+		for i in 0 .. n {
+			unsafe {
+				vals[i] = T(*(&f32(&raw[i * 4])))
+			}
+		}
+		return vtl.from_array[T](vals, x.shape, vtl.TensorData{ memory: .row_major })!
+	} $else {
+		return error('gelu_forward_vulkan: only f32 is GPU-accelerated (got ${T.name})')
+	}
+}

--- a/nn/layers/gelu_vulkan_d_vulkan_test.v
+++ b/nn/layers/gelu_vulkan_d_vulkan_test.v
@@ -1,0 +1,51 @@
+module layers
+
+import storage
+import vtl
+import vsl.vulkan
+import math
+
+fn test_gelu_forward_vulkan_basic() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping gelu test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+	params := storage.new_vulkan_params(dev)
+
+	input_data := [f32(0), 1, -1, 2]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!
+
+	out := gelu_forward_vulkan[f32](input, params)!
+
+	assert out.shape == [4]
+
+	// gelu(0) ≈ 0
+	assert math.abs(f64(out.get([0]))) < 1e-4
+	// gelu(1) ≈ 0.8413
+	assert math.abs(f64(out.get([1])) - 0.8413) < 1e-3
+	// gelu(-1) ≈ -0.1587
+	assert math.abs(f64(out.get([2])) - (-0.1587)) < 1e-3
+	// gelu(2) ≈ 1.9545
+	assert math.abs(f64(out.get([3])) - 1.9545) < 1e-3
+}
+
+fn test_gelu_forward_vulkan_shape_preserved() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping gelu shape test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+	params := storage.new_vulkan_params(dev)
+
+	input_data := [f32(1), 2, 3, 4, 5, 6]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([2, 3])!
+
+	out := gelu_forward_vulkan[f32](input, params)!
+
+	assert out.shape == [2, 3]
+}

--- a/nn/layers/gelu_vulkan_notd_vulkan.v
+++ b/nn/layers/gelu_vulkan_notd_vulkan.v
@@ -1,0 +1,8 @@
+module layers
+
+import vtl
+import storage
+
+pub fn gelu_forward_vulkan[T](x &vtl.Tensor[T], params storage.VulkanStorageParams) !&vtl.Tensor[T] {
+	return error('gelu_forward_vulkan: Vulkan not enabled (compile with -d vulkan)')
+}

--- a/nn/layers/maxpool2d_vulkan_d_vulkan.v
+++ b/nn/layers/maxpool2d_vulkan_d_vulkan.v
@@ -1,0 +1,72 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+pub struct MaxPool2DLayerVulkan[T] {
+pub mut:
+	kernel_size [2]int
+	stride      [2]int
+	padding     [2]int
+	device      &vulkan.Device = unsafe { nil }
+}
+
+pub fn maxpool2d_forward_vulkan[T](input &vtl.Tensor[T], kernel_size [2]int, stride [2]int, padding [2]int, dev &vulkan.Device) !&vtl.Tensor[T] {
+	batch := u32(input.shape[0])
+	channels := u32(input.shape[1])
+	in_h := u32(input.shape[2])
+	in_w := u32(input.shape[3])
+
+	k_h := u32(kernel_size[0])
+	k_w := u32(kernel_size[1])
+	stride_h := u32(stride[0])
+	stride_w := u32(stride[1])
+	pad_h := u32(padding[0])
+	pad_w := u32(padding[1])
+
+	out_h := u32((int(in_h) + 2 * padding[0] - kernel_size[0]) / stride[0] + 1)
+	out_w := u32((int(in_w) + 2 * padding[1] - kernel_size[1]) / stride[1] + 1)
+
+	input_size := batch * channels * in_h * in_w * 4
+	output_size := batch * channels * out_h * out_w * 4
+
+	mut input_buf := dev.buffer(vulkan.DeviceSize(input_size))!
+	defer { input_buf.release() }
+	mut output_buf := dev.buffer(vulkan.DeviceSize(output_size))!
+	defer { output_buf.release() }
+
+	mut input_bytes := []u8{len: int(input_size)}
+	for i := 0; i < int(batch * channels * in_h * in_w); i++ {
+		val := f32(input.get([i / int(channels * in_h * in_w),
+			(i / int(in_h * in_w)) % int(channels),
+			(i / int(in_w)) % int(in_h),
+			i % int(in_w)]))
+		unsafe {
+			*(&f32(&input_bytes[i * 4])) = val
+		}
+	}
+	input_buf.load(input_bytes)!
+
+	vulkan.maxpool2d(dev, output_buf, input_buf, batch, channels, in_h, in_w, k_h, k_w, out_h, out_w, pad_h, pad_w, stride_h, stride_w)!
+
+	mut output_bytes := []u8{len: int(output_size)}
+	output_bytes = output_buf.store(mut output_bytes)!
+
+	mut output_data := []T{len: int(batch * channels * out_h * out_w)}
+	for i in 0 .. int(batch * channels * out_h * out_w) {
+		unsafe {
+			val := *(&f32(&output_bytes[i * 4]))
+			output_data[i] = T(val)
+		}
+	}
+
+	output := vtl.from_1d[T](output_data, vtl.TensorData{})!
+	return output.reshape([int(batch), int(channels), int(out_h), int(out_w)])!
+}
+
+pub fn (layer &MaxPool2DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	if layer.device == unsafe { nil } {
+		return error('MaxPool2DLayerVulkan: device is nil')
+	}
+	return maxpool2d_forward_vulkan[T](input, layer.kernel_size, layer.stride, layer.padding, layer.device)!
+}

--- a/nn/layers/maxpool2d_vulkan_d_vulkan_test.v
+++ b/nn/layers/maxpool2d_vulkan_d_vulkan_test.v
@@ -1,0 +1,60 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+fn test_maxpool2d_forward_vulkan_basic() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping maxpool2d test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	// 1×1×4×4 input
+	input_data := [
+		f32(1), 2, 3, 4,
+		f32(5), 6, 7, 8,
+		f32(9), 10, 11, 12,
+		f32(13), 14, 15, 16,
+	]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([1, 1, 4, 4])!
+
+	kernel_size := [2, 2]!
+	stride := [2, 2]!
+	padding := [0, 0]!
+
+	out := maxpool2d_forward_vulkan[f32](input, kernel_size, stride, padding, dev)!
+
+	assert out.shape == [1, 1, 2, 2]
+
+	// expected: max of each 2×2 patch → 6, 8, 14, 16
+	assert f32(out.get([0, 0, 0, 0])) == f32(6)
+	assert f32(out.get([0, 0, 0, 1])) == f32(8)
+	assert f32(out.get([0, 0, 1, 0])) == f32(14)
+	assert f32(out.get([0, 0, 1, 1])) == f32(16)
+}
+
+fn test_maxpool2d_layer_vulkan() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping maxpool2d layer test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	layer := MaxPool2DLayerVulkan[f32]{
+		kernel_size: [2, 2]!
+		stride:      [2, 2]!
+		padding:     [0, 0]!
+		device:      dev
+	}
+
+	input_data := [f32(3), 1, 2, 4, 5, 7, 6, 8, 9, 11, 10, 12, 13, 15, 14, 16]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([1, 1, 4, 4])!
+
+	out := layer.forward(input)!
+	assert out.shape == [1, 1, 2, 2]
+}

--- a/nn/layers/maxpool2d_vulkan_notd_vulkan.v
+++ b/nn/layers/maxpool2d_vulkan_notd_vulkan.v
@@ -1,0 +1,20 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+pub struct MaxPool2DLayerVulkan[T] {
+pub mut:
+	kernel_size [2]int
+	stride      [2]int
+	padding     [2]int
+	device      voidptr = unsafe { nil }
+}
+
+pub fn maxpool2d_forward_vulkan[T](input &vtl.Tensor[T], kernel_size [2]int, stride [2]int, padding [2]int, dev voidptr) !&vtl.Tensor[T] {
+	return error('maxpool2d_forward_vulkan: Vulkan not enabled (compile with -d vulkan)')
+}
+
+pub fn (layer &MaxPool2DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	return error('MaxPool2DLayerVulkan: Vulkan not enabled (compile with -d vulkan)')
+}


### PR DESCRIPTION
## Summary

Add GPU-accelerated GELU and MaxPool2D layers to VTL's Vulkan backend.

### GELU (Phase 5)
- `gelu_forward_vulkan[T]` — calls `vsl.vulkan.gelu` kernel (tanh approx); f32 native, error on f64
- `gelu_vulkan_d_vulkan.v` / `gelu_vulkan_notd_vulkan.v` conditional pair
- Test: validates gelu(0)≈0, gelu(1)≈0.8413, gelu(-1)≈-0.1587, gelu(2)≈1.9545, shape preserved

### MaxPool2D (Phase 7)
- `maxpool2d_forward_vulkan[T]` + `MaxPool2DLayerVulkan[T]` struct — calls `vsl.vulkan.maxpool2d`
- Matches `AvgPool2DLayerVulkan` interface (explicit `*vulkan.Device` param)
- `maxpool2d_vulkan_d_vulkan.v` / `maxpool2d_vulkan_notd_vulkan.v` conditional pair
- Test: 1×1×4×4 input, 2×2 kernel stride 2 → expected [6,8,14,16]

### Dependencies
- Requires VSL PR #246 (gelu + maxpool2d kernels) — already merged to vsl/main

`v vet` passes (doc warnings only, no errors).