### PR TITLE
feat(nn/layers): add BatchNorm1DLayerVulkan (Phase 6)

### DIFF
--- a/nn/layers/batchnorm_vulkan_d_vulkan.v
+++ b/nn/layers/batchnorm_vulkan_d_vulkan.v
@@ -1,0 +1,60 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+pub struct BatchNorm1DLayerVulkan[T] {
+	eps    f32
+	device &vulkan.Device = unsafe { nil }
+}
+
+// batchnorm1d_forward_vulkan normalises input[N, C] along the batch (N) dimension
+// per feature on the Vulkan GPU (f32 native). Returns the normalised tensor only;
+// caller applies gamma/beta on CPU. f64 returns an error.
+pub fn batchnorm1d_forward_vulkan[T](input &vtl.Tensor[T], eps f32, dev &vulkan.Device) !&vtl.Tensor[T] {
+	if input.shape.len != 2 {
+		return error('batchnorm1d_forward_vulkan: expected 2-D input [N, C], got shape ${input.shape}')
+	}
+	n := u32(input.shape[0])
+	c := u32(input.shape[1])
+	total := int(n * c)
+
+	$if T !is f32 {
+		return error('batchnorm1d_forward_vulkan: only f32 is GPU-accelerated (got ${T.name})')
+	}
+
+	mut src_bytes := []u8{len: total * 4}
+	for idx in 0 .. total {
+		row := idx / int(c)
+		col := idx % int(c)
+		val := f32(input.get([row, col]))
+		unsafe { *(&f32(&src_bytes[idx * 4])) = val }
+	}
+
+	mut src_buf := dev.buffer(vulkan.DeviceSize(u64(total) * 4))!
+	defer { src_buf.release() }
+	src_buf.load(src_bytes)!
+
+	mut dst_buf := dev.buffer(vulkan.DeviceSize(u64(total) * 4))!
+	defer { dst_buf.release() }
+
+	vulkan.batchnorm1d(dev, dst_buf, src_buf, n, c, eps)!
+
+	mut raw := []u8{len: total * 4}
+	dst_buf.store(mut raw)!
+
+	mut vals := []T{len: total}
+	for idx in 0 .. total {
+		unsafe { vals[idx] = T(*(&f32(&raw[idx * 4]))) }
+	}
+
+	out := vtl.from_1d[T](vals, vtl.TensorData{})!
+	return out.reshape([int(n), int(c)])!
+}
+
+pub fn (layer &BatchNorm1DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	if layer.device == unsafe { nil } {
+		return error('BatchNorm1DLayerVulkan: device is nil')
+	}
+	return batchnorm1d_forward_vulkan[T](input, layer.eps, layer.device)!
+}

--- a/nn/layers/batchnorm_vulkan_d_vulkan_test.v
+++ b/nn/layers/batchnorm_vulkan_d_vulkan_test.v
@@ -1,0 +1,51 @@
+module layers
+
+import vtl
+import vsl.vulkan
+import math
+
+fn test_batchnorm1d_forward_vulkan_basic() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping batchnorm1d test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	// 4 samples, 2 features
+	// col0: [1,2,3,4] mean=2.5 var=1.25 → normalised ≈ [-1.342, -0.447, 0.447, 1.342]
+	input_data := [f32(1), 2, 2, 4, 3, 6, 4, 8]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([4, 2])!
+
+	out := batchnorm1d_forward_vulkan[f32](input, f32(1e-5), dev)!
+
+	assert out.shape == [4, 2]
+
+	// column 0 normalised values
+	assert math.abs(f64(out.get([0, 0])) - (-1.342)) < 0.01
+	assert math.abs(f64(out.get([1, 0])) - (-0.447)) < 0.01
+	assert math.abs(f64(out.get([2, 0])) -   0.447)  < 0.01
+	assert math.abs(f64(out.get([3, 0])) -   1.342)  < 0.01
+}
+
+fn test_batchnorm1d_layer_vulkan() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping batchnorm1d layer test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	layer := BatchNorm1DLayerVulkan[f32]{
+		eps:    f32(1e-5)
+		device: dev
+	}
+
+	input_data := [f32(1), 2, 2, 4, 3, 6, 4, 8]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([4, 2])!
+
+	out := layer.forward(input)!
+	assert out.shape == [4, 2]
+}

--- a/nn/layers/batchnorm_vulkan_notd_vulkan.v
+++ b/nn/layers/batchnorm_vulkan_notd_vulkan.v
@@ -1,0 +1,16 @@
+module layers
+
+import vtl
+
+pub struct BatchNorm1DLayerVulkan[T] {
+	eps    f32
+	device voidptr = unsafe { nil }
+}
+
+pub fn batchnorm1d_forward_vulkan[T](input &vtl.Tensor[T], eps f32, dev voidptr) !&vtl.Tensor[T] {
+	return error('batchnorm1d_forward_vulkan: Vulkan not enabled (compile with -d vulkan)')
+}
+
+pub fn (layer &BatchNorm1DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	return error('BatchNorm1DLayerVulkan: Vulkan not enabled (compile with -d vulkan)')
+}


### PR DESCRIPTION
## Summary

Add GPU-accelerated Batch Normalisation layer for 2-D tensors `[N, C]`.

### Implementation
- `batchnorm1d_forward_vulkan[T]` — calls `vsl.vulkan.batchnorm1d` kernel
- One GPU workgroup per feature column; parallel reduction over N samples computes mean + variance
- Returns normalised output only (gamma/beta applied by caller on CPU — same pattern as `LayerNormLayerVulkan`)
- f32 native; f64 returns error
- `BatchNorm1DLayerVulkan[T]` struct with explicit `*vulkan.Device` field

### Files
- `batchnorm_vulkan_d_vulkan.v` — GPU implementation
- `batchnorm_vulkan_notd_vulkan.v` — CPU fallback stub
- `batchnorm_vulkan_d_vulkan_test.v` — two tests (forward + layer)

### Dependencies
- Requires VSL PR #247 (batchnorm1d kernel) — already merged to vsl/main