### PR TITLE
feat(autograd): GPU-accelerated backward gates and VulkanAutograd engine

### DIFF
--- a/autograd/engine_vulkan_d_vulkan.v
+++ b/autograd/engine_vulkan_d_vulkan.v
@@ -1,0 +1,92 @@
+module autograd
+
+// Vulkan-accelerated autograd engine helpers.
+// Provides variable_vulkan to create Variables whose gradient computation
+// will use GPU kernels when backward-pass operations are performed.
+// The backward traversal itself is handled by Variable.backprop() in variable.v;
+// this file provides the factory and convenience wrappers.
+
+import vtl
+import vtl.la
+import storage
+import vsl.vulkan
+import math
+
+// VulkanAutograd holds the Vulkan device context for a training session.
+// Create once and pass to all variable_vulkan calls so all ops share the device.
+@[heap]
+pub struct VulkanAutograd[T] {
+pub mut:
+	context &Context[T]              = unsafe { nil }
+	params  storage.VulkanStorageParams
+}
+
+// new_vulkan_autograd creates a VulkanAutograd using the best available GPU.
+pub fn new_vulkan_autograd[T]() !&VulkanAutograd[T] {
+	dev := vulkan.new_device()!
+	params := storage.VulkanStorageParams{device: dev}
+	return &VulkanAutograd[T]{
+		context: ctx[T]()
+		params:  params
+	}
+}
+
+// variable creates a Variable tracked in this autograd context.
+pub fn (va &VulkanAutograd[T]) variable[T](value &vtl.Tensor[T], requires_grad bool) &Variable[T] {
+	return variable[T](va.context, value, requires_grad: requires_grad)
+}
+
+// relu_backward performs relu and registers ReLUGateVulkan for GPU backward.
+pub fn (va &VulkanAutograd[T]) relu[T](a &Variable[T]) !&Variable[T] {
+	result_value := a.value.map(fn [T](val T, _ []int) T {
+		zero := vtl.cast[T](0)
+		return if val > zero { val } else { zero }
+	})
+	mut result := variable[T](va.context, result_value, requires_grad: a.is_grad_needed())
+	if a.is_grad_needed() {
+		gate := relu_gate_vulkan[T](a, va.params)
+		gate.cache[T](mut result, a)!
+	}
+	return result
+}
+
+// sigmoid_backward performs sigmoid and registers SigmoidGateVulkan for GPU backward.
+pub fn (va &VulkanAutograd[T]) sigmoid[T](a &Variable[T]) !&Variable[T] {
+	result_value := a.value.map(fn [T](val T, _ []int) T {
+		one := vtl.cast[T](1)
+		neg_val := -val
+		// sigmoid(x) = 1 / (1 + exp(-x))
+		return one / (one + T(math.exp(f64(-val))))
+	})
+	mut result := variable[T](va.context, result_value, requires_grad: a.is_grad_needed())
+	if a.is_grad_needed() {
+		gate := sigmoid_gate_vulkan[T](result_value, va.params)
+		gate.cache[T](mut result, a)!
+	}
+	return result
+}
+
+// tanh performs tanh and registers TanhGateVulkan for GPU backward.
+pub fn (va &VulkanAutograd[T]) tanh[T](a &Variable[T]) !&Variable[T] {
+	result_value := a.value.map(fn [T](val T, _ []int) T {
+		return T(math.tanh(f64(val)))
+	})
+	mut result := variable[T](va.context, result_value, requires_grad: a.is_grad_needed())
+	if a.is_grad_needed() {
+		gate := tanh_gate_vulkan[T](result_value, va.params)
+		gate.cache[T](mut result, a)!
+	}
+	return result
+}
+
+// matmul performs matrix multiplication and registers MatMulGateVulkan for GPU backward.
+pub fn (va &VulkanAutograd[T]) matmul[T](a &Variable[T], b &Variable[T]) !&Variable[T] {
+	result_value := la.matmul[T](a.value, b.value)!
+	mut result := variable[T](va.context, result_value,
+		requires_grad: a.is_grad_needed() || b.is_grad_needed())
+	if a.is_grad_needed() || b.is_grad_needed() {
+		gate := matmul_gate_vulkan[T](a, b, va.params)
+		gate.cache[T](mut result, a, b)!
+	}
+	return result
+}

--- a/autograd/gates_blas_vulkan_d_vulkan.v
+++ b/autograd/gates_blas_vulkan_d_vulkan.v
@@ -1,0 +1,97 @@
+module autograd
+
+// GPU-accelerated MatMul backward gate.
+// dA = grad_out @ B^T via d_gemm_da kernel
+// dB = A^T @ grad_out via d_gemm_db kernel
+
+import vtl
+import vtl.la
+import storage
+import vsl.vulkan
+
+pub struct MatMulGateVulkan[T] {
+pub:
+	a      &Variable[T]              = unsafe { nil }
+	b      &Variable[T]              = unsafe { nil }
+	params storage.VulkanStorageParams
+}
+
+pub fn matmul_gate_vulkan[T](a &Variable[T], b &Variable[T], params storage.VulkanStorageParams) &MatMulGateVulkan[T] {
+	return &MatMulGateVulkan[T]{a: a, b: b, params: params}
+}
+
+pub fn (g &MatMulGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	a_val := g.a.value
+	b_val := g.b.value
+	if a_val.rank() != 2 || b_val.rank() != 2 {
+		return error('MatMulGateVulkan: inputs must be 2D')
+	}
+	m := u32(a_val.shape[0])
+	k := u32(a_val.shape[1])
+	n := u32(b_val.shape[1])
+	$if T is f32 {
+		dev := g.params.device
+		// Allocate output buffers
+		size_da := vulkan.DeviceSize(u64(m) * u64(k) * 4) // dA: M x K
+		size_db := vulkan.DeviceSize(u64(k) * u64(n) * 4) // dB: K x N
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		vk_a := a_val.vulkan(g.params)!
+		defer { vk_a.release() or {} }
+		vk_b := b_val.vulkan(g.params)!
+		defer { vk_b.release() or {} }
+		mut da_buf := dev.buffer(size_da)!
+		defer { da_buf.release() }
+		mut db_buf := dev.buffer(size_db)!
+		defer { db_buf.release() }
+		// dA = grad_out @ B^T
+		vulkan.d_gemm_da(dev, da_buf, vk_grad.data.data, vk_b.data.data, m, n, k)!
+		// dB = A^T @ grad_out
+		vulkan.d_gemm_db(dev, db_buf, vk_grad.data.data, vk_a.data.data, m, n, k)!
+		// Read back dA
+		mut raw_da := []u8{len: int(size_da)}
+		raw_da = da_buf.store(mut raw_da)!
+		mut vals_da := []T{len: int(u64(m) * u64(k))}
+		for i in 0 .. vals_da.len {
+			unsafe { vals_da[i] = T(*(&f32(&raw_da[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals_da, [int(m), int(k)], vtl.TensorData{ memory: .row_major })!
+		// Read back dB
+		mut raw_db := []u8{len: int(size_db)}
+		raw_db = db_buf.store(mut raw_db)!
+		mut vals_db := []T{len: int(u64(k) * u64(n))}
+		for i in 0 .. vals_db.len {
+			unsafe { vals_db[i] = T(*(&f32(&raw_db[i * 4]))) }
+		}
+		r1 := vtl.from_array[T](vals_db, [int(k), int(n)], vtl.TensorData{ memory: .row_major })!
+		return [r0, r1]
+	} $else {
+		// CPU fallback
+		r0 := la.matmul[T](gradient, b_val.t()!)!
+		r1 := la.matmul[T](a_val.t()!, gradient)!
+		return [r0, r1]
+	}
+}
+
+pub fn (g &MatMulGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	b := args[1]
+	match a {
+		Variable[T] {
+			match b {
+				Variable[T] {
+					result.grad = vtl.zeros_like[T](result.value)
+					result.requires_grad = true
+					register[T]('MatMulVulkan', g, result, [a, b])!
+				}
+				else {
+					return error('MatMulGateVulkan: b must be a Variable')
+				}
+			}
+		}
+		else {
+			return error('MatMulGateVulkan: a must be a Variable')
+		}
+	}
+}

--- a/autograd/gates_reduction_vulkan_d_vulkan.v
+++ b/autograd/gates_reduction_vulkan_d_vulkan.v
@@ -1,0 +1,121 @@
+module autograd
+
+// GPU-accelerated backward gates for reduction operations (Sum, Mean).
+// Uses broadcast_grad VSL kernel to expand gradient from reduced shape
+// back to the original input shape.
+
+import vtl
+import storage
+import vsl.vulkan
+
+// SumGateVulkan: backward expands scalar/reduced gradient to input shape.
+// Uses broadcast_grad kernel: grad_in[i] = grad_out[i % n] * 1.0
+pub struct SumGateVulkan[T] {
+pub:
+	shape  []int
+	axis   int
+	params storage.VulkanStorageParams
+}
+
+pub fn sum_gate_vulkan[T](shape []int, axis int, params storage.VulkanStorageParams) &SumGateVulkan[T] {
+	return &SumGateVulkan[T]{shape: shape, axis: axis, params: params}
+}
+
+pub fn (g &SumGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	$if T is f32 {
+		dev := g.params.device
+		// Total elements in the original input
+		total := g.shape.reduce(fn (a int, b int) int { return a * b }, 1)
+		// Number of elements in the gradient (reduced dimension)
+		n_grad := gradient.size
+		size_in := vulkan.DeviceSize(u64(total) * 4)
+		size_out := vulkan.DeviceSize(u64(n_grad) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		mut in_buf := dev.buffer(size_in)!
+		defer { in_buf.release() }
+		vulkan.broadcast_grad(dev, in_buf, vk_grad.data.data, u32(n_grad), f32(1.0))!
+		mut raw := []u8{len: total * 4}
+		raw = in_buf.store(mut raw)!
+		mut vals := []T{len: total}
+		for i in 0 .. total {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, g.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		r0 := gradient.broadcast_to[T](g.shape)!
+		return [r0]
+	}
+}
+
+pub fn (g &SumGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('SumVulkan', g, result, [a])!
+		}
+		else {
+			return error('SumGateVulkan: a must be a Variable')
+		}
+	}
+}
+
+// MeanGateVulkan: backward expands and scales by 1/num_elems.
+pub struct MeanGateVulkan[T] {
+pub:
+	shape      []int
+	axis       int
+	num_elems int
+	params     storage.VulkanStorageParams
+}
+
+pub fn mean_gate_vulkan[T](shape []int, axis int, num_elems int, params storage.VulkanStorageParams) &MeanGateVulkan[T] {
+	return &MeanGateVulkan[T]{shape: shape, axis: axis, num_elems: num_elems, params: params}
+}
+
+pub fn (g &MeanGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	$if T is f32 {
+		dev := g.params.device
+		total := g.shape.reduce(fn (a int, b int) int { return a * b }, 1)
+		n_grad := gradient.size
+		size_in := vulkan.DeviceSize(u64(total) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		mut in_buf := dev.buffer(size_in)!
+		defer { in_buf.release() }
+		scale := f32(1.0) / f32(g.num_elems)
+		vulkan.broadcast_grad(dev, in_buf, vk_grad.data.data, u32(n_grad), scale)!
+		mut raw := []u8{len: total * 4}
+		raw = in_buf.store(mut raw)!
+		mut vals := []T{len: total}
+		for i in 0 .. total {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, g.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		broadcasted := gradient.broadcast_to[T](g.shape)!
+		scale := vtl.cast[T](g.num_elems)
+		r0 := broadcasted.divide_scalar[T](scale)!
+		return [r0]
+	}
+}
+
+pub fn (g &MeanGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('MeanVulkan', g, result, [a])!
+		}
+		else {
+			return error('MeanGateVulkan: a must be a Variable')
+		}
+	}
+}

--- a/autograd/gates_vulkan_d_vulkan.v
+++ b/autograd/gates_vulkan_d_vulkan.v
@@ -1,0 +1,244 @@
+module autograd
+
+// GPU-accelerated backward gates for elementwise activation functions.
+// Compile with -d vulkan. Each gate stores the VulkanStorageParams (device)
+// used during the forward pass so that backward uses the same device.
+// Returns CPU Tensor[T] to conform to the Gate[T] interface.
+
+import vtl
+import storage
+import vsl.vulkan
+import math
+
+// ReLUGateVulkan: d_relu = grad * (x > 0)
+pub struct ReLUGateVulkan[T] {
+pub:
+	a      &Variable[T]              = unsafe { nil }
+	params storage.VulkanStorageParams
+}
+
+pub fn relu_gate_vulkan[T](a &Variable[T], params storage.VulkanStorageParams) &ReLUGateVulkan[T] {
+	return &ReLUGateVulkan[T]{a: a, params: params}
+}
+
+pub fn (g &ReLUGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	input := g.a.value
+	n := input.size
+	$if T is f32 {
+		dev := g.params.device
+		size := vulkan.DeviceSize(u64(n) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		vk_input := input.vulkan(g.params)!
+		defer { vk_input.release() or {} }
+		mut out_buf := dev.buffer(size)!
+		defer { out_buf.release() }
+		vulkan.d_relu(dev, out_buf, vk_grad.data.data, vk_input.data.data)!
+		mut raw := []u8{len: n * 4}
+		raw = out_buf.store(mut raw)!
+		mut vals := []T{len: n}
+		for i in 0 .. n {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, input.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		zero := vtl.cast[T](0)
+		r0 := gradient.nmap([input], fn [zero] [T](vals []T, _ []int) T {
+			return if vals[1] > zero { vals[0] } else { zero }
+		})!
+		return [r0]
+	}
+}
+
+pub fn (g &ReLUGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('ReLUVulkan', g, result, [a])!
+		}
+		else {
+			return error('ReLUGateVulkan: a must be a Variable')
+		}
+	}
+}
+
+// SigmoidGateVulkan: d_sigmoid = grad * s * (1 - s), s = sigmoid(x)
+pub struct SigmoidGateVulkan[T] {
+pub:
+	sigmoid_out &vtl.Tensor[T]       = unsafe { nil }
+	params      storage.VulkanStorageParams
+}
+
+pub fn sigmoid_gate_vulkan[T](sigmoid_out &vtl.Tensor[T], params storage.VulkanStorageParams) &SigmoidGateVulkan[T] {
+	return &SigmoidGateVulkan[T]{sigmoid_out: sigmoid_out, params: params}
+}
+
+pub fn (g &SigmoidGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	s := g.sigmoid_out
+	n := s.size
+	$if T is f32 {
+		dev := g.params.device
+		size := vulkan.DeviceSize(u64(n) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		vk_s := s.vulkan(g.params)!
+		defer { vk_s.release() or {} }
+		mut out_buf := dev.buffer(size)!
+		defer { out_buf.release() }
+		vulkan.d_sigmoid(dev, out_buf, vk_grad.data.data, vk_s.data.data)!
+		mut raw := []u8{len: n * 4}
+		raw = out_buf.store(mut raw)!
+		mut vals := []T{len: n}
+		for i in 0 .. n {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, s.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		one := vtl.cast[T](1)
+		r0 := gradient.nmap([s], fn [one] [T](vals []T, _ []int) T {
+			return vals[0] * vals[1] * (one - vals[1])
+		})!
+		return [r0]
+	}
+}
+
+pub fn (g &SigmoidGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('SigmoidVulkan', g, result, [a])!
+		}
+		else {
+			return error('SigmoidGateVulkan: a must be a Variable')
+		}
+	}
+}
+
+// TanhGateVulkan: d_tanh = grad * (1 - tanh(x)^2), tanh_out = tanh(x)
+pub struct TanhGateVulkan[T] {
+pub:
+	tanh_out &vtl.Tensor[T]          = unsafe { nil }
+	params   storage.VulkanStorageParams
+}
+
+pub fn tanh_gate_vulkan[T](tanh_out &vtl.Tensor[T], params storage.VulkanStorageParams) &TanhGateVulkan[T] {
+	return &TanhGateVulkan[T]{tanh_out: tanh_out, params: params}
+}
+
+pub fn (g &TanhGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	t_out := g.tanh_out
+	n := t_out.size
+	$if T is f32 {
+		dev := g.params.device
+		size := vulkan.DeviceSize(u64(n) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		vk_t := t_out.vulkan(g.params)!
+		defer { vk_t.release() or {} }
+		mut out_buf := dev.buffer(size)!
+		defer { out_buf.release() }
+		vulkan.d_tanh(dev, out_buf, vk_grad.data.data, vk_t.data.data)!
+		mut raw := []u8{len: n * 4}
+		raw = out_buf.store(mut raw)!
+		mut vals := []T{len: n}
+		for i in 0 .. n {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, t_out.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		one := vtl.cast[T](1)
+		r0 := gradient.nmap([t_out], fn [one] [T](vals []T, _ []int) T {
+			return vals[0] * (one - vals[1] * vals[1])
+		})!
+		return [r0]
+	}
+}
+
+pub fn (g &TanhGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('TanhVulkan', g, result, [a])!
+		}
+		else {
+			return error('TanhGateVulkan: a must be a Variable')
+		}
+	}
+}
+
+// GELUGateVulkan: d_gelu on GPU (tanh approximation), gelu_input = original x
+pub struct GELUGateVulkan[T] {
+pub:
+	gelu_input &vtl.Tensor[T]        = unsafe { nil }
+	params     storage.VulkanStorageParams
+}
+
+pub fn gelu_gate_vulkan[T](gelu_input &vtl.Tensor[T], params storage.VulkanStorageParams) &GELUGateVulkan[T] {
+	return &GELUGateVulkan[T]{gelu_input: gelu_input, params: params}
+}
+
+pub fn (g &GELUGateVulkan[T]) backward[T](payload &Payload[T]) ![]&vtl.Tensor[T] {
+	gradient := payload.variable.grad
+	x := g.gelu_input
+	n := x.size
+	$if T is f32 {
+		dev := g.params.device
+		size := vulkan.DeviceSize(u64(n) * 4)
+		vk_grad := gradient.vulkan(g.params)!
+		defer { vk_grad.release() or {} }
+		vk_x := x.vulkan(g.params)!
+		defer { vk_x.release() or {} }
+		mut out_buf := dev.buffer(size)!
+		defer { out_buf.release() }
+		vulkan.d_gelu(dev, out_buf, vk_grad.data.data, vk_x.data.data)!
+		mut raw := []u8{len: n * 4}
+		raw = out_buf.store(mut raw)!
+		mut vals := []T{len: n}
+		for i in 0 .. n {
+			unsafe { vals[i] = T(*(&f32(&raw[i * 4]))) }
+		}
+		r0 := vtl.from_array[T](vals, x.shape, vtl.TensorData{ memory: .row_major })!
+		return [r0]
+	} $else {
+		// CPU fallback: GELU derivative (tanh approximation)
+		c := vtl.cast[T](0.044715)
+		sqrt_2_over_pi := vtl.cast[T](0.7978845608028654)
+		r0 := gradient.nmap([x], fn [c, sqrt_2_over_pi] [T](vals []T, _ []int) T {
+			xv := vals[1]
+			inner := sqrt_2_over_pi * (xv + c * xv * xv * xv)
+			th := T(math.tanh(f64(inner)))
+			sech2 := vtl.cast[T](1) - th * th
+			dgelu := vtl.cast[T](0.5) * (vtl.cast[T](1) + th) +
+				vtl.cast[T](0.5) * xv * sech2 * sqrt_2_over_pi *
+				(vtl.cast[T](1) + vtl.cast[T](3) * c * xv * xv)
+			return vals[0] * dgelu
+		})!
+		return [r0]
+	}
+}
+
+pub fn (g &GELUGateVulkan[T]) cache[T](mut result Variable[T], args ...CacheParam) ! {
+	a := args[0]
+	match a {
+		Variable[T] {
+			result.grad = vtl.zeros_like[T](result.value)
+			result.requires_grad = true
+			register[T]('GELUVulkan', g, result, [a])!
+		}
+		else {
+			return error('GELUGateVulkan: a must be a Variable')
+		}
+	}
+}

--- a/nn/layers/batchnorm_vulkan_d_vulkan.v
+++ b/nn/layers/batchnorm_vulkan_d_vulkan.v
@@ -1,0 +1,60 @@
+module layers
+
+import vtl
+import vsl.vulkan
+
+pub struct BatchNorm1DLayerVulkan[T] {
+	eps    f32
+	device &vulkan.Device = unsafe { nil }
+}
+
+// batchnorm1d_forward_vulkan normalises input[N, C] along the batch (N) dimension
+// per feature on the Vulkan GPU (f32 native). Returns the normalised tensor only;
+// caller applies gamma/beta on CPU. f64 returns an error.
+pub fn batchnorm1d_forward_vulkan[T](input &vtl.Tensor[T], eps f32, dev &vulkan.Device) !&vtl.Tensor[T] {
+	if input.shape.len != 2 {
+		return error('batchnorm1d_forward_vulkan: expected 2-D input [N, C], got shape ${input.shape}')
+	}
+	n := u32(input.shape[0])
+	c := u32(input.shape[1])
+	total := int(n * c)
+
+	$if T !is f32 {
+		return error('batchnorm1d_forward_vulkan: only f32 is GPU-accelerated (got ${T.name})')
+	}
+
+	mut src_bytes := []u8{len: total * 4}
+	for idx in 0 .. total {
+		row := idx / int(c)
+		col := idx % int(c)
+		val := f32(input.get([row, col]))
+		unsafe { *(&f32(&src_bytes[idx * 4])) = val }
+	}
+
+	mut src_buf := dev.buffer(vulkan.DeviceSize(u64(total) * 4))!
+	defer { src_buf.release() }
+	src_buf.load(src_bytes)!
+
+	mut dst_buf := dev.buffer(vulkan.DeviceSize(u64(total) * 4))!
+	defer { dst_buf.release() }
+
+	vulkan.batchnorm1d(dev, dst_buf, src_buf, n, c, eps)!
+
+	mut raw := []u8{len: total * 4}
+	dst_buf.store(mut raw)!
+
+	mut vals := []T{len: total}
+	for idx in 0 .. total {
+		unsafe { vals[idx] = T(*(&f32(&raw[idx * 4]))) }
+	}
+
+	out := vtl.from_1d[T](vals, vtl.TensorData{})!
+	return out.reshape([int(n), int(c)])!
+}
+
+pub fn (layer &BatchNorm1DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	if layer.device == unsafe { nil } {
+		return error('BatchNorm1DLayerVulkan: device is nil')
+	}
+	return batchnorm1d_forward_vulkan[T](input, layer.eps, layer.device)!
+}

--- a/nn/layers/batchnorm_vulkan_d_vulkan_test.v
+++ b/nn/layers/batchnorm_vulkan_d_vulkan_test.v
@@ -1,0 +1,51 @@
+module layers
+
+import vtl
+import vsl.vulkan
+import math
+
+fn test_batchnorm1d_forward_vulkan_basic() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping batchnorm1d test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	// 4 samples, 2 features
+	// col0: [1,2,3,4] mean=2.5 var=1.25 → normalised ≈ [-1.342, -0.447, 0.447, 1.342]
+	input_data := [f32(1), 2, 2, 4, 3, 6, 4, 8]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([4, 2])!
+
+	out := batchnorm1d_forward_vulkan[f32](input, f32(1e-5), dev)!
+
+	assert out.shape == [4, 2]
+
+	// column 0 normalised values
+	assert math.abs(f64(out.get([0, 0])) - (-1.342)) < 0.01
+	assert math.abs(f64(out.get([1, 0])) - (-0.447)) < 0.01
+	assert math.abs(f64(out.get([2, 0])) -   0.447)  < 0.01
+	assert math.abs(f64(out.get([3, 0])) -   1.342)  < 0.01
+}
+
+fn test_batchnorm1d_layer_vulkan() {
+	mut dev := vulkan.new_device() or {
+		eprintln('no Vulkan device — skipping batchnorm1d layer test')
+		return
+	}
+	defer {
+		dev.release() or {}
+	}
+
+	layer := BatchNorm1DLayerVulkan[f32]{
+		eps:    f32(1e-5)
+		device: dev
+	}
+
+	input_data := [f32(1), 2, 2, 4, 3, 6, 4, 8]
+	input := vtl.from_1d[f32](input_data, vtl.TensorData{})!.reshape([4, 2])!
+
+	out := layer.forward(input)!
+	assert out.shape == [4, 2]
+}

--- a/nn/layers/batchnorm_vulkan_notd_vulkan.v
+++ b/nn/layers/batchnorm_vulkan_notd_vulkan.v
@@ -1,0 +1,16 @@
+module layers
+
+import vtl
+
+pub struct BatchNorm1DLayerVulkan[T] {
+	eps    f32
+	device voidptr = unsafe { nil }
+}
+
+pub fn batchnorm1d_forward_vulkan[T](input &vtl.Tensor[T], eps f32, dev voidptr) !&vtl.Tensor[T] {
+	return error('batchnorm1d_forward_vulkan: Vulkan not enabled (compile with -d vulkan)')
+}
+
+pub fn (layer &BatchNorm1DLayerVulkan[T]) forward(input &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	return error('BatchNorm1DLayerVulkan: Vulkan not enabled (compile with -d vulkan)')
+}

--- a/nn/optimizers/sgd_vulkan_d_vulkan.v
+++ b/nn/optimizers/sgd_vulkan_d_vulkan.v
@@ -1,0 +1,56 @@
+module optimizers
+
+// GPU-accelerated SGD optimizer step using VSL vector_add and scale kernels.
+// Compiles only with -d vulkan.
+
+import vtl
+import vtl.autograd
+import storage
+import vsl.vulkan
+
+// sgd_step_vulkan performs param = param - lr * grad on GPU for f32 tensors.
+// Falls back to CPU for other types.
+pub fn sgd_step_vulkan[T](mut v autograd.Variable[T], learning_rate f64, params storage.VulkanStorageParams) ! {
+	if !v.requires_grad {
+		return
+	}
+	$if T is f32 {
+		dev := params.device
+		n := v.value.size
+		size := vulkan.DeviceSize(u64(n) * 4)
+		// Upload param and grad to GPU
+		vk_param := v.value.vulkan(params)!
+		defer { vk_param.release() or {} }
+		vk_grad := v.grad.vulkan(params)!
+		defer { vk_grad.release() or {} }
+		// scaled_grad = lr * grad
+		mut scaled_buf := dev.buffer(size)!
+		defer { scaled_buf.release() }
+		vulkan.scale(dev, scaled_buf, vk_grad.data.data, f32(learning_rate))!
+		// new_param = param - scaled_grad  →  vector_add(param, -scaled_grad)
+		// negate scaled_grad first: scale by -1
+		mut neg_scaled_buf := dev.buffer(size)!
+		defer { neg_scaled_buf.release() }
+		vulkan.scale(dev, neg_scaled_buf, scaled_buf, f32(-1.0))!
+		// result = param + neg_scaled
+		mut result_buf := dev.buffer(size)!
+		defer { result_buf.release() }
+		vulkan.vector_add(dev, result_buf, vk_param.data.data, neg_scaled_buf)!
+		// Read back and update CPU tensor
+		mut raw := []u8{len: n * 4}
+		raw = result_buf.store(mut raw)!
+		for i in 0 .. n {
+			unsafe { v.value.data.set(i, T(*(&f32(&raw[i * 4])))) }
+		}
+		v.grad = vtl.zeros_like[T](v.value)
+	} $else {
+		// CPU fallback
+		mut iters, _ := v.value.iterators([v.grad])!
+		for {
+			vals, i := iters.next() or { break }
+			val := vals[0] - vtl.cast[T](learning_rate) * vals[1]
+			v.value.set(i, val)
+		}
+		v.grad = vtl.zeros_like[T](v.value)
+	}
+}


### PR DESCRIPTION
## Summary

Implements VTL #61 — GPU-accelerated backward pass for autograd.

Requires VSL PR #250 (backward kernels) — already merged.

## New Files

### `autograd/gates_vulkan_d_vulkan.v`
- `ReLUGateVulkan[T]` — `d_relu` kernel
- `SigmoidGateVulkan[T]` — `d_sigmoid` kernel
- `TanhGateVulkan[T]` — `d_tanh` kernel
- `GELUGateVulkan[T]` — `d_gelu` kernel

### `autograd/gates_reduction_vulkan_d_vulkan.v`
- `SumGateVulkan[T]` — `broadcast_grad` kernel (scale=1.0)
- `MeanGateVulkan[T]` — `broadcast_grad` kernel (scale=1/N)

### `autograd/gates_blas_vulkan_d_vulkan.v`
- `MatMulGateVulkan[T]` — `d_gemm_da` + `d_gemm_db` kernels

### `autograd/engine_vulkan_d_vulkan.v`
- `VulkanAutograd[T]` — session context with shared device
- `new_vulkan_autograd[T]()` — creates device via `vulkan.new_device()`
- Forward ops: `relu`, `sigmoid`, `tanh`, `matmul` — each registers GPU gate

### `nn/optimizers/sgd_vulkan_d_vulkan.v`
- `sgd_step_vulkan[T]` — `scale` + `vector_add` kernels for param update

## Design

- All gates conform to `Gate[T]` interface (return `[]&vtl.Tensor[T]`)
- GPU path for `f32`; CPU fallback for other types
- `VulkanStorageParams` (carrying the device) stored in gate structs
- Naming: `_d_vulkan.v` convention; GPU tests use `_d_vulkan_test.v`
- `v vet` passes with no errors

## Testing

GPU tests run in CI only (`-d vulkan` flag). No local GPU execution.