### PR TITLE
feat(vcl): OpenCL VTL backend — VclTensor ops + la/matmul_vcl (closes #62)

### DIFF
--- a/la/vcl_d_vcl.v
+++ b/la/vcl_d_vcl.v
@@ -1,0 +1,115 @@
+module la
+
+import vtl
+import vsl.vcl
+import vsl.vcl.compute
+
+// matmul_vcl performs matrix multiplication on GPU via OpenCL.
+// Both tensors must be 2D. Uses f64 precision via vsl.vcl.compute.gemm_vcl.
+// Returns a Tensor[T] on the CPU.
+pub fn matmul_vcl[T](a &vtl.Tensor[T], b &vtl.Tensor[T]) !&vtl.Tensor[T] {
+	a.assert_matrix()!
+	b.assert_matrix()!
+	if a.shape[1] != b.shape[0] {
+		return error('matmul_vcl: incompatible shapes ${a.shape} x ${b.shape}')
+	}
+
+	m := a.shape[0]
+	k := a.shape[1]
+	n := b.shape[1]
+
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+
+	// Flatten to row-major f64 then convert to column-major for OpenCL GEMM
+	a_rm := a.copy(.row_major)
+	b_rm := b.copy(.row_major)
+	a_f64 := a_rm.as_f64().to_array()
+	b_f64 := b_rm.as_f64().to_array()
+
+	a_col := row_to_col_major(a_f64, m, k)
+	b_col := row_to_col_major(b_f64, k, n)
+
+	c_col := compute.gemm_vcl(mut dev, a_col, b_col, m, n, k)!
+	c_row := col_to_row_major(c_col, m, n)
+
+	c_data := c_row.map(vtl.cast[T](it))
+	mut c := vtl.from_1d[T](c_data, vtl.TensorData{})!
+	return c.reshape([m, n])!
+}
+
+// matmul_vcl_f32 is the f32 specialization of matmul_vcl.
+pub fn matmul_vcl_f32(a &vtl.Tensor[f32], b &vtl.Tensor[f32]) !&vtl.Tensor[f32] {
+	a.assert_matrix()!
+	b.assert_matrix()!
+	if a.shape[1] != b.shape[0] {
+		return error('matmul_vcl_f32: incompatible shapes ${a.shape} x ${b.shape}')
+	}
+
+	m := a.shape[0]
+	k := a.shape[1]
+	n := b.shape[1]
+
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+
+	a_rm := a.copy(.row_major)
+	b_rm := b.copy(.row_major)
+	a_f32 := a_rm.as_f32().to_array()
+	b_f32 := b_rm.as_f32().to_array()
+
+	a_col := row_to_col_major_f32(a_f32, m, k)
+	b_col := row_to_col_major_f32(b_f32, k, n)
+
+	c_col := compute.gemm_vcl_f32(mut dev, a_col, b_col, m, n, k)!
+	c_row := col_to_row_major_f32(c_col, m, n)
+
+	mut c := vtl.from_1d[f32](c_row, vtl.TensorData{})!
+	return c.reshape([m, n])!
+}
+
+// --- layout helpers ---
+
+fn row_to_col_major(data []f64, rows int, cols int) []f64 {
+	mut out := []f64{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r + c * rows] = data[r * cols + c]
+		}
+	}
+	return out
+}
+
+fn col_to_row_major(data []f64, rows int, cols int) []f64 {
+	mut out := []f64{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r * cols + c] = data[r + c * rows]
+		}
+	}
+	return out
+}
+
+fn row_to_col_major_f32(data []f32, rows int, cols int) []f32 {
+	mut out := []f32{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r + c * rows] = data[r * cols + c]
+		}
+	}
+	return out
+}
+
+fn col_to_row_major_f32(data []f32, rows int, cols int) []f32 {
+	mut out := []f32{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r * cols + c] = data[r + c * rows]
+		}
+	}
+	return out
+}

--- a/la/vcl_notd_vcl.v
+++ b/la/vcl_notd_vcl.v
@@ -1,0 +1,1 @@
+module la

--- a/la/vcl_test_d_vcl.v
+++ b/la/vcl_test_d_vcl.v
@@ -1,0 +1,53 @@
+module la
+
+import vtl
+
+fn test_matmul_vcl_identity() {
+	// 2x2 identity * identity = identity
+	a := vtl.from_2d[f64]([[1.0, 0.0], [0.0, 1.0]]) or { panic(err) }
+	b := vtl.from_2d[f64]([[1.0, 0.0], [0.0, 1.0]]) or { panic(err) }
+	c := matmul_vcl[f64](a, b) or { panic('matmul_vcl failed: ${err}') }
+	ca := c.to_array()
+	assert ca[0] == 1.0
+	assert ca[1] == 0.0
+	assert ca[2] == 0.0
+	assert ca[3] == 1.0
+}
+
+fn test_matmul_vcl_basic() {
+	// [[1,2],[3,4]] * [[5,6],[7,8]] = [[19,22],[43,50]]
+	a := vtl.from_2d[f64]([[1.0, 2.0], [3.0, 4.0]]) or { panic(err) }
+	b := vtl.from_2d[f64]([[5.0, 6.0], [7.0, 8.0]]) or { panic(err) }
+	c := matmul_vcl[f64](a, b) or { panic('matmul_vcl failed: ${err}') }
+	ca := c.to_array()
+	assert ca[0] == 19.0
+	assert ca[1] == 22.0
+	assert ca[2] == 43.0
+	assert ca[3] == 50.0
+}
+
+fn test_matmul_vcl_f32_basic() {
+	a := vtl.from_2d[f32]([[1.0, 2.0], [3.0, 4.0]]) or { panic(err) }
+	b := vtl.from_2d[f32]([[5.0, 6.0], [7.0, 8.0]]) or { panic(err) }
+	c := matmul_vcl_f32(a, b) or { panic('matmul_vcl_f32 failed: ${err}') }
+	ca := c.to_array()
+	assert ca[0] == f32(19.0)
+	assert ca[1] == f32(22.0)
+	assert ca[2] == f32(43.0)
+	assert ca[3] == f32(50.0)
+}
+
+fn test_matmul_vcl_rect() {
+	// [2x3] * [3x2]
+	a := vtl.from_2d[f64]([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]) or { panic(err) }
+	b := vtl.from_2d[f64]([[7.0, 8.0], [9.0, 10.0], [11.0, 12.0]]) or { panic(err) }
+	c := matmul_vcl[f64](a, b) or { panic('matmul_vcl rect failed: ${err}') }
+	assert c.shape == [2, 2]
+	ca := c.to_array()
+	// row0: 1*7+2*9+3*11=58, 1*8+2*10+3*12=64
+	// row1: 4*7+5*9+6*11=139, 4*8+5*10+6*12=154
+	assert ca[0] == 58.0
+	assert ca[1] == 64.0
+	assert ca[2] == 139.0
+	assert ca[3] == 154.0
+}

--- a/tensor_vcl_ops_d_vcl.v
+++ b/tensor_vcl_ops_d_vcl.v
@@ -1,0 +1,179 @@
+module vtl
+
+import storage
+import vsl.vcl
+import vsl.vcl.compute
+
+// matmul returns the matrix product of two VclTensors via OpenCL GEMM.
+// Both tensors must be 2-D. Returns a new VclTensor on the same device.
+pub fn (a &VclTensor[T]) matmul[T](b &VclTensor[T]) !&VclTensor[T] {
+	if !a.is_matrix() || !b.is_matrix() {
+		return error('VclTensor.matmul: both tensors must be 2-D')
+	}
+	if a.shape[1] != b.shape[0] {
+		return error('VclTensor.matmul: incompatible shapes ${a.shape} x ${b.shape}')
+	}
+
+	m := a.shape[0]
+	k := a.shape[1]
+	n := b.shape[1]
+
+	a_arr := a.data.to_array()!
+	b_arr := b.data.to_array()!
+
+	// compute.gemm_vcl uses column-major layout; convert from row-major
+	a_f64 := a_arr.map(f64(cast[f64](it)))
+	b_f64 := b_arr.map(f64(cast[f64](it)))
+	a_col := vcl_row_to_col_f64(a_f64, m, k)
+	b_col := vcl_row_to_col_f64(b_f64, k, n)
+
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+
+	c_col := compute.gemm_vcl(mut dev, a_col, b_col, m, n, k)!
+	c_row := vcl_col_to_row_f64(c_col, m, n)
+	c := c_row.map(cast[T](it))
+	return vcl_tensor_from_array[T](c, [m, n], mut dev)!
+}
+
+// add returns elementwise addition of two VclTensors (same shape).
+pub fn (a &VclTensor[T]) add[T](b &VclTensor[T]) !&VclTensor[T] {
+	if a.shape != b.shape {
+		return error('VclTensor.add: shape mismatch ${a.shape} vs ${b.shape}')
+	}
+	a_arr := a.data.to_array()!
+	b_arr := b.data.to_array()!
+	a_f64 := a_arr.map(f64(cast[f64](it)))
+	b_f64 := b_arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	c_f64 := compute.add_vec_vcl(mut dev, a_f64, b_f64)!
+	c := c_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](c, a.shape, mut dev)!
+}
+
+// multiply returns elementwise multiplication of two VclTensors (same shape).
+pub fn (a &VclTensor[T]) multiply[T](b &VclTensor[T]) !&VclTensor[T] {
+	if a.shape != b.shape {
+		return error('VclTensor.multiply: shape mismatch ${a.shape} vs ${b.shape}')
+	}
+	a_arr := a.data.to_array()!
+	b_arr := b.data.to_array()!
+	a_f64 := a_arr.map(f64(cast[f64](it)))
+	b_f64 := b_arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	c_f64 := compute.mul_vec_vcl(mut dev, a_f64, b_f64)!
+	c := c_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](c, a.shape, mut dev)!
+}
+
+// relu applies ReLU activation on a VclTensor element-wise.
+pub fn (t &VclTensor[T]) relu[T]() !&VclTensor[T] {
+	arr := t.data.to_array()!
+	x_f64 := arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	y_f64 := compute.relu_vcl(mut dev, x_f64)!
+	y := y_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
+}
+
+// sigmoid applies sigmoid activation on a VclTensor element-wise.
+pub fn (t &VclTensor[T]) sigmoid[T]() !&VclTensor[T] {
+	arr := t.data.to_array()!
+	x_f64 := arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	y_f64 := compute.sigmoid_vcl(mut dev, x_f64)!
+	y := y_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
+}
+
+// tanh_act applies tanh activation on a VclTensor element-wise.
+pub fn (t &VclTensor[T]) tanh_act[T]() !&VclTensor[T] {
+	arr := t.data.to_array()!
+	x_f64 := arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	y_f64 := compute.tanh_vcl(mut dev, x_f64)!
+	y := y_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
+}
+
+// add_scalar adds a scalar to every element of a VclTensor.
+pub fn (t &VclTensor[T]) add_scalar[T](s T) !&VclTensor[T] {
+	arr := t.data.to_array()!
+	x_f64 := arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	y_f64 := compute.add_scalar_vcl(mut dev, x_f64, f64(cast[f64](s)))!
+	y := y_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
+}
+
+// mul_scalar multiplies every element of a VclTensor by a scalar.
+pub fn (t &VclTensor[T]) mul_scalar[T](s T) !&VclTensor[T] {
+	arr := t.data.to_array()!
+	x_f64 := arr.map(f64(cast[f64](it)))
+	mut dev := vcl.get_default_device()!
+	defer {
+		dev.release() or {}
+	}
+	y_f64 := compute.mul_scalar_vcl(mut dev, x_f64, f64(cast[f64](s)))!
+	y := y_f64.map(cast[T](it))
+	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
+}
+
+// --- internal helpers ---
+
+fn vcl_row_to_col_f64(data []f64, rows int, cols int) []f64 {
+	mut out := []f64{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r + c * rows] = data[r * cols + c]
+		}
+	}
+	return out
+}
+
+fn vcl_col_to_row_f64(data []f64, rows int, cols int) []f64 {
+	mut out := []f64{len: data.len}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			out[r * cols + c] = data[r + c * rows]
+		}
+	}
+	return out
+}
+
+fn vcl_tensor_from_array[T](data []T, shape []int, mut dev vcl.Device) !&VclTensor[T] {
+	mut vec := dev.vector[T](data.len)!
+	err := <-vec.load(data)
+	if err !is none {
+		return err
+	}
+	sz := size_from_shape(shape)
+	strides := strides_from_shape(shape, .row_major)
+	return &VclTensor[T]{
+		data:    &storage.VclStorage[T]{data: vec}
+		memory:  .row_major
+		size:    sz
+		shape:   shape
+		strides: strides
+	}
+}

--- a/tensor_vcl_ops_notd_vcl.v
+++ b/tensor_vcl_ops_notd_vcl.v
@@ -1,0 +1,1 @@
+module vtl

--- a/vcl_ops_test_d_vcl.v
+++ b/vcl_ops_test_d_vcl.v
@@ -1,0 +1,55 @@
+module vtl
+
+fn test_vcl_tensor_add() {
+	a := from_2d[f64]([[1.0, 2.0], [3.0, 4.0]]) or { panic(err) }
+	b := from_2d[f64]([[10.0, 20.0], [30.0, 40.0]]) or { panic(err) }
+	va := a.vcl(storage.VclStorageParams{}) or { panic('vcl transfer failed: ${err}') }
+	vb := b.vcl(storage.VclStorageParams{}) or { panic('vcl transfer failed: ${err}') }
+	vc := va.add(vb) or { panic('VclTensor.add failed: ${err}') }
+	result := vc.cpu() or { panic(err) }
+	arr := result.to_array()
+	assert arr[0] == 11.0
+	assert arr[1] == 22.0
+	assert arr[2] == 33.0
+	assert arr[3] == 44.0
+}
+
+fn test_vcl_tensor_multiply() {
+	a := from_1d[f64]([2.0, 3.0, 4.0], TensorData{}) or { panic(err) }
+	b := from_1d[f64]([5.0, 6.0, 7.0], TensorData{}) or { panic(err) }
+	va := a.vcl(storage.VclStorageParams{}) or { panic(err) }
+	vb := b.vcl(storage.VclStorageParams{}) or { panic(err) }
+	vc := va.multiply(vb) or { panic('VclTensor.multiply failed: ${err}') }
+	result := vc.cpu() or { panic(err) }
+	arr := result.to_array()
+	assert arr[0] == 10.0
+	assert arr[1] == 18.0
+	assert arr[2] == 28.0
+}
+
+fn test_vcl_tensor_relu() {
+	a := from_1d[f64]([-2.0, -1.0, 0.0, 1.0, 2.0], TensorData{}) or { panic(err) }
+	va := a.vcl(storage.VclStorageParams{}) or { panic(err) }
+	vb := va.relu() or { panic('VclTensor.relu failed: ${err}') }
+	result := vb.cpu() or { panic(err) }
+	arr := result.to_array()
+	assert arr[0] == 0.0
+	assert arr[1] == 0.0
+	assert arr[2] == 0.0
+	assert arr[3] == 1.0
+	assert arr[4] == 2.0
+}
+
+fn test_vcl_tensor_matmul() {
+	a := from_2d[f64]([[1.0, 2.0], [3.0, 4.0]]) or { panic(err) }
+	b := from_2d[f64]([[5.0, 6.0], [7.0, 8.0]]) or { panic(err) }
+	va := a.vcl(storage.VclStorageParams{}) or { panic(err) }
+	vb := b.vcl(storage.VclStorageParams{}) or { panic(err) }
+	vc := va.matmul(vb) or { panic('VclTensor.matmul failed: ${err}') }
+	result := vc.cpu() or { panic(err) }
+	arr := result.to_array()
+	assert arr[0] == 19.0
+	assert arr[1] == 22.0
+	assert arr[2] == 43.0
+	assert arr[3] == 50.0
+}


### PR DESCRIPTION
## Summary

Implements the OpenCL compute backend for VTL, closing #62.

Wires `vsl.vcl.compute` GPU kernels into tensor operations on `VclTensor[T]` and the `la/` linear algebra module.

## New files

### `la/vcl_d_vcl.v`
- `matmul_vcl[T]` — GPU matrix multiplication using `vsl.vcl.compute.gemm_vcl` (f64)
- `matmul_vcl_f32` — f32 specialisation via `gemm_vcl_f32`
- Internal row-major ↔ column-major layout helpers (matches VSL gemm convention)

### `tensor_vcl_ops_d_vcl.v`
| Method | Operation |
|--------|-----------|
| `.matmul(b)` | GPU GEMM (2-D tensors) |
| `.add(b)` | Elementwise add |
| `.multiply(b)` | Elementwise multiply |
| `.relu()` | ReLU activation |
| `.sigmoid()` | Sigmoid activation |
| `.tanh_act()` | Tanh activation |
| `.add_scalar(s)` | Scalar broadcast add |
| `.mul_scalar(s)` | Scalar broadcast multiply |

### Tests
- `la/vcl_test_d_vcl.v` — 4 matmul tests (identity, 2×2, f32, rectangular)
- `vcl_ops_test_d_vcl.v` — add, multiply, relu, matmul on `VclTensor`

## Design notes
- All ops cast through `f64` via `vsl.vcl.compute`; cast back to T via `vtl.cast[T]`
- Conditional compilation via `_d_vcl.v` / `_notd_vcl.v` guards
- Depends on VSL PR #254 (fix `.data()` API bug in `vcl/compute/`) — already merged

## Checklist
- [x] `v vet -d vcl .` — no errors
- [x] Conditional compilation guards in place
- [ ] CI tests (run with `-d vcl`) on merge