### PR TITLE
docs: GPU backend guide + strict README coverage for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and a full neural network module.
   losses (MSE, BCE, CrossEntropy, Huber, …); optimizers (Adam, AdamW, RMSProp, AdaGrad, SGD)
 - **Linear algebra** — VSL-backed: matmul, solve, lstsq, qr, lu, cholesky, pinv, trace, norm, SVD
 - **Hardware acceleration** — zero-copy sharing with C libraries via `vtl.Tensor.data`
+  plus Vulkan (`-d vulkan`) and OpenCL/VCL (`-d vcl`) backend paths
 
 ## Quick start
 
@@ -105,6 +106,18 @@ All tutorials live in [`docs/`](docs/README.md):
 | [TUTORIAL_ADVANCED_LA.md](docs/TUTORIAL_ADVANCED_LA.md) | trace / norm / qr / lu / cholesky / pinv |
 | [TUTORIAL_BROADCASTING.md](docs/TUTORIAL_BROADCASTING.md) | Broadcasting rules |
 | [TUTORIAL_SLICING.md](docs/TUTORIAL_SLICING.md) | Slicing and views |
+| [TUTORIAL_GPU_BACKENDS.md](docs/TUTORIAL_GPU_BACKENDS.md) | Vulkan + OpenCL/VCL backend guide |
+
+## Benchmarking
+
+Backend comparison benchmark is available in [`benchmark/`](benchmark/README.md).
+
+```sh
+v run benchmark/main.v
+v -d vcl run benchmark/main.v
+v -d vulkan run benchmark/main.v
+v -d vulkan -d vcl run benchmark/main.v
+```
 
 ## License
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,49 @@
+# VTL Backend Benchmark
+
+This benchmark compares matrix multiplication (`matmul`) across:
+
+- CPU (`vtl.la.matmul`)
+- Vulkan backend (`-d vulkan`)
+- OpenCL/VCL backend (`-d vcl`)
+
+## What it runs
+
+`benchmark/main.v` executes `matmul` over square matrices for sizes:
+
+- `64 x 64`
+- `128 x 128`
+- `256 x 256`
+
+Each size is repeated 3 times and averaged.
+
+## Run commands
+
+```sh
+# CPU only
+v run benchmark/main.v
+
+# CPU + OpenCL/VCL
+v -d vcl run benchmark/main.v
+
+# CPU + Vulkan
+v -d vulkan run benchmark/main.v
+
+# CPU + both GPU backends
+v -d vulkan -d vcl run benchmark/main.v
+```
+
+## Output format
+
+Each line prints timing and speedup against CPU:
+
+```text
+matmul [128x128]: CPU=8.12ms | Vulkan=1.20ms (6.77x) | VCL=1.55ms (5.24x)
+```
+
+If a backend is not enabled, it is omitted.
+
+## Notes
+
+- Benchmarks are sensitive to GPU model, thermal state, and driver/runtime.
+- First run can include setup overhead (shader/kernel setup, memory init).
+- Use repeated runs for stable comparisons.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ neural network module.
 | [TUTORIAL_REDUCTIONS.md](./TUTORIAL_REDUCTIONS.md) | argmax/argmin/cumsum/cumprod |
 | [TUTORIAL_ADVANCED_LA.md](./TUTORIAL_ADVANCED_LA.md) | trace/norm/outer/qr/lu/cholesky/pinv |
 | [TUTORIAL_OPTIMIZERS.md](./TUTORIAL_OPTIMIZERS.md) | Adam/AdamW/RMSProp/AdaGrad/SGD + schedulers |
+| [TUTORIAL_GPU_BACKENDS.md](./TUTORIAL_GPU_BACKENDS.md) | Vulkan/OpenCL (VCL) backend usage and benchmarking |
 
 ## VSL — V Standard Library
 

--- a/docs/TUTORIAL_GPU_BACKENDS.md
+++ b/docs/TUTORIAL_GPU_BACKENDS.md
@@ -1,0 +1,117 @@
+# Tutorial: GPU Backends (Vulkan + OpenCL/VCL)
+
+This tutorial explains how to run VTL workloads on GPU backends and benchmark them against CPU.
+
+## Current backend status
+
+- **Vulkan backend (`-d vulkan`)**
+  - Autograd gates and training-related paths are available for selected operations.
+  - Tensor and NN integrations are available for Vulkan-enabled builds.
+- **OpenCL backend via VCL (`-d vcl`)**
+  - `VclTensor` conversion and compute ops are available.
+  - LA integration includes `la.matmul_vcl` and VCL-backed tensor operations.
+
+## Build flags
+
+Use compile-time flags to activate GPU code paths:
+
+```sh
+# CPU only
+v run your_program.v
+
+# OpenCL/VCL backend
+v -d vcl run your_program.v
+
+# Vulkan backend
+v -d vulkan run your_program.v
+
+# Both enabled
+v -d vulkan -d vcl run your_program.v
+```
+
+## OpenCL/VCL workflow
+
+```v ignore
+import vtl
+import vtl.storage
+
+// CPU tensor
+x := vtl.from_2d[f64]([[1.0, 2.0], [3.0, 4.0]])!
+
+// Move to VCL storage (device auto-selected when device is nil)
+vx := x.vcl(storage.VclStorageParams{})!
+
+// Run VCL-backed tensor ops
+vy := vx.relu()!
+vz := vy.add_scalar(1.0)!
+
+// Bring back to CPU
+cpu := vz.cpu()!
+println(cpu)
+```
+
+## Vulkan workflow
+
+```v ignore
+import vtl
+import vtl.storage
+
+x := vtl.from_2d[f32]([[1.0, 2.0], [3.0, 4.0]])!
+params := storage.VulkanStorageParams{}
+
+vx := x.vulkan(params)!
+vy := vx.relu()!
+out := vy.cpu()!
+println(out)
+```
+
+## Linear algebra on OpenCL
+
+```v ignore
+import vtl
+import vtl.la
+
+// A[2x2] * B[2x2]
+a := vtl.from_2d[f64]([[1, 2], [3, 4]])!
+b := vtl.from_2d[f64]([[5, 6], [7, 8]])!
+
+c := la.matmul_vcl[f64](a, b)!
+println(c)
+```
+
+## Backend benchmark module
+
+VTL includes a benchmark module to compare CPU, Vulkan, and VCL:
+
+```sh
+# CPU only
+v run benchmark/main.v
+
+# CPU + OpenCL/VCL
+v -d vcl run benchmark/main.v
+
+# CPU + Vulkan
+v -d vulkan run benchmark/main.v
+
+# CPU + Vulkan + VCL
+v -d vulkan -d vcl run benchmark/main.v
+```
+
+See [`benchmark/README.md`](../benchmark/README.md) for details.
+
+## MNIST and GPU notes
+
+The `examples/nn_mnist` example demonstrates a full training pipeline.
+GPU backends can be enabled through flags, but acceleration depends on
+the exact ops used by the model and current backend coverage.
+
+For practical guidance, see:
+
+- [`examples/nn_mnist/README.md`](../examples/nn_mnist/README.md)
+- [`examples/vtl_opencl_vcl_support/README.md`](../examples/vtl_opencl_vcl_support/README.md)
+
+## Troubleshooting
+
+- If `-d vcl` fails, verify OpenCL runtime/ICD installation and device availability.
+- If `-d vulkan` fails, verify Vulkan loader + GPU driver.
+- Keep backend and compiler versions aligned with current VSL/VTL main branches.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,32 @@
+# VTL Examples
+
+This directory contains runnable examples for tensor ops, datasets, autograd, and neural networks.
+
+## Run pattern
+
+```sh
+v run examples/<example_folder>/main.v
+```
+
+Some examples use alternate file names (for example, `main_not_ci.v`) when excluded from CI.
+
+## GPU-related examples
+
+- `vtl_opencl_vcl_support` — OpenCL/VCL conversion and execution flow
+- `nn_mnist` — MNIST training example (can be built with `-d vcl` / `-d vulkan`)
+
+## Full list
+
+- `autograd_backprop`
+- `datasets_imdb`
+- `datasets_mnist`
+- `nn_autoencoder_simple`
+- `nn_mnist`
+- `nn_multiclass_iris`
+- `nn_regression_sine`
+- `nn_simple_two_layer`
+- `nn_xor`
+- `vtl_basic_usage`
+- `vtl_opencl_vcl_support`
+- `vtl_plot_scatter_colorscale`
+- `vtl_vandermont`

--- a/examples/datasets_imdb/README.md
+++ b/examples/datasets_imdb/README.md
@@ -1,0 +1,19 @@
+# IMDB Dataset Example
+
+This example demonstrates loading the IMDB dataset through `vtl.datasets`.
+
+## What it covers
+
+- Dataset download/loading
+- Basic split access and inspection workflow
+
+## Run
+
+```sh
+v run examples/datasets_imdb/main.v
+```
+
+## Notes
+
+- The first run may download dataset files.
+- This example focuses on data access; training/modeling is handled by separate NN examples.

--- a/examples/datasets_mnist/README.md
+++ b/examples/datasets_mnist/README.md
@@ -1,0 +1,20 @@
+# MNIST Dataset Example
+
+This example demonstrates loading the MNIST dataset using `vtl.datasets`.
+
+## What it covers
+
+- Dataset download/loading
+- Train/test split usage
+- Basic tensor-ready data flow
+
+## Run
+
+```sh
+v run examples/datasets_mnist/main.v
+```
+
+## Notes
+
+- First execution may download dataset artifacts.
+- For model training, see `examples/nn_mnist`.

--- a/examples/nn_mnist/README.md
+++ b/examples/nn_mnist/README.md
@@ -1,0 +1,38 @@
+# MNIST Neural Network Training
+
+This example trains a simple feed-forward network on MNIST.
+
+Architecture:
+
+- `784 -> 128 -> ReLU -> 64 -> ReLU -> 10`
+- Loss: MSE with one-hot targets
+- Optimizer: SGD
+
+## Run
+
+```sh
+# CPU
+v run examples/nn_mnist/main.v
+
+# OpenCL/VCL-enabled build
+v -d vcl run examples/nn_mnist/main.v
+
+# Vulkan-enabled build
+v -d vulkan run examples/nn_mnist/main.v
+```
+
+## GPU backend notes
+
+- Backend flags enable GPU code paths where supported by the current operation set.
+- End-to-end speedup depends on the exact model operations and backend coverage.
+- Use `benchmark/main.v` for controlled backend comparisons on matmul workloads.
+
+## Dataset
+
+- MNIST is downloaded automatically on first run.
+- Input normalization: `[0, 255] -> [0.0, 1.0]`.
+
+## Practical tips
+
+- Start with fewer batches/epochs while validating environment setup.
+- Check OpenCL/Vulkan runtime availability before large runs.

--- a/examples/vtl_opencl_vcl_support/README.md
+++ b/examples/vtl_opencl_vcl_support/README.md
@@ -11,5 +11,5 @@ Read the [docs](https://vlang.github.io/vsl/vcl.html) of the V Computing Languag
 To run the example, execute the following command:
 
 ```sh
-v -d vcl run examples/opencl_vcl_support/main_not_ci.v
+v -d vcl run examples/vtl_opencl_vcl_support/main_not_ci.v
 ```

--- a/examples/vtl_plot_scatter_colorscale/README.md
+++ b/examples/vtl_plot_scatter_colorscale/README.md
@@ -1,0 +1,14 @@
+# Scatter Colorscale Example
+
+This example demonstrates a scatter plot with colorscale support using VTL + VSL plotting.
+
+## Run
+
+```sh
+v run examples/vtl_plot_scatter_colorscale/main.v
+```
+
+## Notes
+
+- Plot rendering depends on your plotting backend/runtime.
+- Useful as a minimal plotting integration smoke test.


### PR DESCRIPTION
## Scope

This PR updates VTL documentation and examples coverage to align with current GPU-related additions.

## Changes

- Added `docs/TUTORIAL_GPU_BACKENDS.md`
  - Vulkan/OpenCL(VCL) build flags
  - tensor conversion workflows
  - backend benchmark usage
  - MNIST/GPU usage notes
- Added `benchmark/README.md`
- Updated `README.md` and `docs/README.md` with GPU/backend benchmark links
- Added missing example READMEs:
  - `examples/datasets_imdb/README.md`
  - `examples/datasets_mnist/README.md`
  - `examples/nn_mnist/README.md`
  - `examples/vtl_plot_scatter_colorscale/README.md`
- Added `examples/README.md` index
- Fixed run path in `examples/vtl_opencl_vcl_support/README.md`

## Policy compliance

Implements strict policy: every `examples/*` folder now contains `README.md`.

## Validation

- `v fmt -verify .` ✅
- `v check-md -hide-warnings vtl/` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added comprehensive GPU backend guide covering Vulkan and OpenCL/VCL support with workflows and troubleshooting.
* Added benchmarking documentation including matrix-multiplication benchmark instructions across CPU and GPU backends.
* Added example documentation for MNIST and IMDB datasets with training instructions.
* Added tutorial guides for GPU-accelerated tensor operations and backend selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->