### PR TITLE
refactor(gpu): migrate VCL integration to unified vsl.compute API

### DIFF
--- a/docs/TUTORIAL_GPU_BACKENDS.md
+++ b/docs/TUTORIAL_GPU_BACKENDS.md
@@ -4,6 +4,11 @@ This tutorial explains how to run VTL workloads on GPU backends and benchmark th
 
 ## Current backend status
 
+VTL uses the unified backend-agnostic entrypoint from VSL:
+
+- `vsl.compute` for operation dispatch
+- backend implementations under `vsl/vcl/compute` and `vsl/vulkan/compute`
+
 - **Vulkan backend (`-d vulkan`)**
   - Autograd gates and training-related paths are available for selected operations.
   - Tensor and NN integrations are available for Vulkan-enabled builds.
@@ -65,7 +70,7 @@ out := vy.cpu()!
 println(out)
 ```
 
-## Linear algebra on OpenCL
+## Linear algebra on OpenCL (via unified compute dispatch)
 
 ```v ignore
 import vtl

--- a/la/vcl_d_vcl.v
+++ b/la/vcl_d_vcl.v
@@ -1,12 +1,10 @@
 module la
 
 import vtl
-import vsl.vcl
-import vsl.vcl.compute
+import vsl.compute as vsl_compute
 
-// matmul_vcl performs matrix multiplication on GPU via OpenCL.
-// Both tensors must be 2D. Uses f64 precision via vsl.vcl.compute.gemm_vcl.
-// Returns a Tensor[T] on the CPU.
+// matmul_vcl performs matrix multiplication via the unified VSL compute API
+// with VCL backend selected.
 pub fn matmul_vcl[T](a &vtl.Tensor[T], b &vtl.Tensor[T]) !&vtl.Tensor[T] {
 	a.assert_matrix()!
 	b.assert_matrix()!
@@ -18,22 +16,10 @@ pub fn matmul_vcl[T](a &vtl.Tensor[T], b &vtl.Tensor[T]) !&vtl.Tensor[T] {
 	k := a.shape[1]
 	n := b.shape[1]
 
-	mut dev := vcl.get_default_device()!
-	defer {
-		dev.release() or {}
-	}
-
-	// Flatten to row-major f64 then convert to column-major for OpenCL GEMM
-	a_rm := a.copy(.row_major)
-	b_rm := b.copy(.row_major)
-	a_f64 := a_rm.as_f64().to_array()
-	b_f64 := b_rm.as_f64().to_array()
-
-	a_col := row_to_col_major(a_f64, m, k)
-	b_col := row_to_col_major(b_f64, k, n)
-
-	c_col := compute.gemm_vcl(mut dev, a_col, b_col, m, n, k)!
-	c_row := col_to_row_major(c_col, m, n)
+	cctx := vsl_compute.new_context(.vcl)
+	a_f64 := a.copy(.row_major).as_f64().to_array()
+	b_f64 := b.copy(.row_major).as_f64().to_array()
+	c_row := vsl_compute.gemm(cctx, a_f64, b_f64, m, n, k)!
 
 	c_data := c_row.map(vtl.cast[T](it))
 	mut c := vtl.from_1d[T](c_data, vtl.TensorData{})!
@@ -52,64 +38,12 @@ pub fn matmul_vcl_f32(a &vtl.Tensor[f32], b &vtl.Tensor[f32]) !&vtl.Tensor[f32] 
 	k := a.shape[1]
 	n := b.shape[1]
 
-	mut dev := vcl.get_default_device()!
-	defer {
-		dev.release() or {}
-	}
-
-	a_rm := a.copy(.row_major)
-	b_rm := b.copy(.row_major)
-	a_f32 := a_rm.as_f32().to_array()
-	b_f32 := b_rm.as_f32().to_array()
-
-	a_col := row_to_col_major_f32(a_f32, m, k)
-	b_col := row_to_col_major_f32(b_f32, k, n)
-
-	c_col := compute.gemm_vcl_f32(mut dev, a_col, b_col, m, n, k)!
-	c_row := col_to_row_major_f32(c_col, m, n)
+	cctx := vsl_compute.new_context(.vcl)
+	a_f64 := a.copy(.row_major).as_f64().to_array()
+	b_f64 := b.copy(.row_major).as_f64().to_array()
+	c_row_f64 := vsl_compute.gemm(cctx, a_f64, b_f64, m, n, k)!
+	c_row := c_row_f64.map(f32(it))
 
 	mut c := vtl.from_1d[f32](c_row, vtl.TensorData{})!
 	return c.reshape([m, n])!
-}
-
-// --- layout helpers ---
-
-fn row_to_col_major(data []f64, rows int, cols int) []f64 {
-	mut out := []f64{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r + c * rows] = data[r * cols + c]
-		}
-	}
-	return out
-}
-
-fn col_to_row_major(data []f64, rows int, cols int) []f64 {
-	mut out := []f64{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r * cols + c] = data[r + c * rows]
-		}
-	}
-	return out
-}
-
-fn row_to_col_major_f32(data []f32, rows int, cols int) []f32 {
-	mut out := []f32{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r + c * rows] = data[r * cols + c]
-		}
-	}
-	return out
-}
-
-fn col_to_row_major_f32(data []f32, rows int, cols int) []f32 {
-	mut out := []f32{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r * cols + c] = data[r + c * rows]
-		}
-	}
-	return out
 }

--- a/tensor_vcl_ops_d_vcl.v
+++ b/tensor_vcl_ops_d_vcl.v
@@ -2,7 +2,7 @@ module vtl
 
 import storage
 import vsl.vcl
-import vsl.vcl.compute
+import vsl.compute as vsl_compute
 
 // matmul returns the matrix product of two VclTensors via OpenCL GEMM.
 // Both tensors must be 2-D. Returns a new VclTensor on the same device.
@@ -24,17 +24,14 @@ pub fn (a &VclTensor[T]) matmul[T](b &VclTensor[T]) !&VclTensor[T] {
 	// compute.gemm_vcl uses column-major layout; convert from row-major
 	a_f64 := a_arr.map(f64(cast[f64](it)))
 	b_f64 := b_arr.map(f64(cast[f64](it)))
-	a_col := vcl_row_to_col_f64(a_f64, m, k)
-	b_col := vcl_row_to_col_f64(b_f64, k, n)
 
+	mut cctx := vsl_compute.new_context(.vcl)
+	c_row := vsl_compute.gemm(cctx, a_f64, b_f64, m, n, k)!
+	c := c_row.map(cast[T](it))
 	mut dev := vcl.get_default_device()!
 	defer {
 		dev.release() or {}
 	}
-
-	c_col := compute.gemm_vcl(mut dev, a_col, b_col, m, n, k)!
-	c_row := vcl_col_to_row_f64(c_col, m, n)
-	c := c_row.map(cast[T](it))
 	return vcl_tensor_from_array[T](c, [m, n], mut dev)!
 }
 
@@ -51,7 +48,8 @@ pub fn (a &VclTensor[T]) add[T](b &VclTensor[T]) !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	c_f64 := compute.add_vec_vcl(mut dev, a_f64, b_f64)!
+	mut cctx := vsl_compute.new_context(.vcl)
+	c_f64 := vsl_compute.add_vec(cctx, a_f64, b_f64)!
 	c := c_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](c, a.shape, mut dev)!
 }
@@ -69,7 +67,8 @@ pub fn (a &VclTensor[T]) multiply[T](b &VclTensor[T]) !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	c_f64 := compute.mul_vec_vcl(mut dev, a_f64, b_f64)!
+	mut cctx := vsl_compute.new_context(.vcl)
+	c_f64 := vsl_compute.mul_vec(cctx, a_f64, b_f64)!
 	c := c_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](c, a.shape, mut dev)!
 }
@@ -82,7 +81,8 @@ pub fn (t &VclTensor[T]) relu[T]() !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	y_f64 := compute.relu_vcl(mut dev, x_f64)!
+	mut cctx := vsl_compute.new_context(.vcl)
+	y_f64 := vsl_compute.relu(cctx, x_f64)!
 	y := y_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
 }
@@ -95,7 +95,8 @@ pub fn (t &VclTensor[T]) sigmoid[T]() !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	y_f64 := compute.sigmoid_vcl(mut dev, x_f64)!
+	mut cctx := vsl_compute.new_context(.vcl)
+	y_f64 := vsl_compute.sigmoid(cctx, x_f64)!
 	y := y_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
 }
@@ -108,7 +109,8 @@ pub fn (t &VclTensor[T]) tanh_act[T]() !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	y_f64 := compute.tanh_vcl(mut dev, x_f64)!
+	mut cctx := vsl_compute.new_context(.vcl)
+	y_f64 := vsl_compute.tanh(cctx, x_f64)!
 	y := y_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
 }
@@ -121,7 +123,8 @@ pub fn (t &VclTensor[T]) add_scalar[T](s T) !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	y_f64 := compute.add_scalar_vcl(mut dev, x_f64, f64(cast[f64](s)))!
+	mut cctx := vsl_compute.new_context(.vcl)
+	y_f64 := vsl_compute.add_scalar(cctx, x_f64, f64(cast[f64](s)))!
 	y := y_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
 }
@@ -134,32 +137,13 @@ pub fn (t &VclTensor[T]) mul_scalar[T](s T) !&VclTensor[T] {
 	defer {
 		dev.release() or {}
 	}
-	y_f64 := compute.mul_scalar_vcl(mut dev, x_f64, f64(cast[f64](s)))!
+	mut cctx := vsl_compute.new_context(.vcl)
+	y_f64 := vsl_compute.mul_scalar(cctx, x_f64, f64(cast[f64](s)))!
 	y := y_f64.map(cast[T](it))
 	return vcl_tensor_from_array[T](y, t.shape, mut dev)!
 }
 
 // --- internal helpers ---
-
-fn vcl_row_to_col_f64(data []f64, rows int, cols int) []f64 {
-	mut out := []f64{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r + c * rows] = data[r * cols + c]
-		}
-	}
-	return out
-}
-
-fn vcl_col_to_row_f64(data []f64, rows int, cols int) []f64 {
-	mut out := []f64{len: data.len}
-	for r in 0 .. rows {
-		for c in 0 .. cols {
-			out[r * cols + c] = data[r + c * rows]
-		}
-	}
-	return out
-}
 
 fn vcl_tensor_from_array[T](data []T, shape []int, mut dev vcl.Device) !&VclTensor[T] {
 	mut vec := dev.vector[T](data.len)!


### PR DESCRIPTION
## Summary

Migrates VTL OpenCL/VCL-facing paths to use the new backend-agnostic `vsl.compute` API.

## Changes

- `la/vcl_d_vcl.v`
  - `matmul_vcl` and `matmul_vcl_f32` now dispatch through `vsl.compute.gemm`
- `tensor_vcl_ops_d_vcl.v`
  - VCL tensor ops now use `vsl.compute` for:
    - `matmul`, `relu`, `sigmoid`, `tanh_act`
    - `add`, `multiply`
    - `add_scalar`, `mul_scalar`
- `docs/TUTORIAL_GPU_BACKENDS.md`
  - Clarifies standardized architecture:
    - `vsl.compute` dispatch layer
    - backend implementations in `vsl/vcl/compute` and `vsl/vulkan/compute`

## Validation

- `v vet -d vcl .` ✅
- `v check-md -hide-warnings vtl/` ✅
