### PR TITLE
feat: runtime backend selection for NN and LA dispatch

### DIFF
--- a/autograd/context.v
+++ b/autograd/context.v
@@ -1,6 +1,7 @@
 module autograd
 
 import vtl
+import vsl.compute
 
 // Context keeps track of the computational graph for
 // a number of operations. Variables that interact with each
@@ -15,12 +16,26 @@ pub mut:
 	// If no_grad is set to true, operations will not
 	// be cached, and backpropagation will not be possible
 	no_grad bool
+	// Backend preference used by NN/LA runtime dispatch.
+	compute_backend compute.Backend = .auto
+	// If true, fail when preferred backend is unavailable.
+	compute_strict bool
 }
 
 // Contexts can only be initialized as empty, and
 // a generic type must be provided
 pub fn ctx[T]() &Context[T] {
 	return &Context[T]{}
+}
+
+// set_compute_backend configures backend preference for runtime dispatch.
+pub fn (mut ctx Context[T]) set_compute_backend(backend compute.Backend) {
+	ctx.compute_backend = backend
+}
+
+// set_compute_strict toggles strict mode for runtime backend dispatch.
+pub fn (mut ctx Context[T]) set_compute_strict(strict bool) {
+	ctx.compute_strict = strict
 }
 
 pub fn (ctx &Context[T]) len() int {

--- a/docs/TUTORIAL_GPU_BACKENDS.md
+++ b/docs/TUTORIAL_GPU_BACKENDS.md
@@ -34,6 +34,54 @@ v -d vulkan run your_program.v
 v -d vulkan -d vcl run your_program.v
 ```
 
+Compile-time flags define which backends are available in the binary.
+Runtime policy selects which backend to use at execution time.
+
+## Runtime backend selection
+
+You can choose backend at runtime without changing model code:
+
+```sh
+# Auto selection (default)
+v -d vulkan -d vcl run your_program.v
+
+# Force Vulkan
+VTL_BACKEND=vulkan v -d vulkan -d vcl run your_program.v
+
+# Force OpenCL/VCL
+VTL_BACKEND=vcl v -d vulkan -d vcl run your_program.v
+
+# Force CPU
+VTL_BACKEND=cpu v -d vulkan -d vcl run your_program.v
+
+# Strict mode: fail if preferred backend is unavailable
+VTL_BACKEND=vulkan VTL_BACKEND_STRICT=1 v -d vulkan -d vcl run your_program.v
+```
+
+Supported values for `VTL_BACKEND`: `auto`, `cpu`, `vulkan`, `vcl`.
+
+Current runtime-dispatched NN/LA coverage:
+
+- `la.matmul` through `Linear` layer
+- `ReLU`, `Sigmoid`, `Tanh` layers
+- `Conv2D` layer (tries Vulkan path first when selected, then CPU fallback when not strict)
+- `MaxPool2D`, `AveragePool2D`, `GlobalAveragePool2D` layers (Vulkan try + CPU fallback)
+- `Softmax` layer for 1-D tensors (Vulkan try + CPU fallback)
+- `BatchNorm1D` inference path (Vulkan normalize + CPU affine/fallback)
+
+You can also configure backend policy directly on a model context:
+
+```v ignore
+import vsl.compute
+import vtl.autograd
+import vtl.nn.models
+
+mut ctx := autograd.ctx[f64]()
+mut model := models.sequential_from_ctx[f64](ctx)
+model.set_backend(compute.Backend.vulkan)
+model.set_backend_strict(false)
+```
+
 ## OpenCL/VCL workflow
 
 ```v ignore

--- a/examples/nn_mnist/main.v
+++ b/examples/nn_mnist/main.v
@@ -5,6 +5,7 @@ import vtl.autograd
 import vtl.datasets
 import vtl.nn.models
 import vtl.nn.optimizers
+import vtl.runtime
 
 const batch_size = 32
 const epochs = 3
@@ -16,7 +17,10 @@ const batches = 100
 
 fn main() {
 	// Autograd context / neuralnet graph
-	ctx := autograd.ctx[f64]()
+	mut ctx := autograd.ctx[f64]()
+	policy := runtime.policy_from_env() or { runtime.ExecutionPolicy{} }
+	runtime.apply_policy[f64](mut ctx, policy)
+	println('Runtime backend policy: backend=${policy.backend}, strict=${policy.strict}')
 
 	// Load the MNIST dataset (downloads automatically on first run)
 	println('Loading MNIST dataset...')

--- a/la/la.v
+++ b/la/la.v
@@ -1,6 +1,7 @@
 module la
 
 import vsl.la as vsl_la
+import vsl.compute as vsl_compute
 import vtl
 
 pub fn dot[T](a &vtl.Tensor[T], b &vtl.Tensor[T]) !&vtl.Tensor[f64] {
@@ -32,10 +33,27 @@ pub fn inv[T](t &vtl.Tensor[T]) !&vtl.Tensor[f64] {
 }
 
 pub fn matmul[T](a &vtl.Tensor[T], b &vtl.Tensor[T]) !&vtl.Tensor[f64] {
+	return matmul_with_backend[T](a, b, .cpu, false)
+}
+
+// matmul_with_backend computes matrix multiplication using runtime backend selection.
+pub fn matmul_with_backend[T](a &vtl.Tensor[T], b &vtl.Tensor[T], backend vsl_compute.Backend, strict bool) !&vtl.Tensor[f64] {
 	a.assert_matrix()!
 	b.assert_matrix()!
 	if a.shape[1] != b.shape[0] {
 		return error('Invalid shapes for matrix multiplication ${a.shape} and ${b.shape}')
+	}
+	if backend != .cpu {
+		m := a.shape[0]
+		k := a.shape[1]
+		n := b.shape[1]
+		mut cctx := vsl_compute.new_context(backend)
+		cctx.strict = strict
+		a_f64 := a.copy(.row_major).as_f64().to_array()
+		b_f64 := b.copy(.row_major).as_f64().to_array()
+		c_row := vsl_compute.gemm(cctx, a_f64, b_f64, m, n, k)!
+		mut c := vtl.from_1d[f64](c_row, vtl.TensorData{})!
+		return c.reshape([m, n])!
 	}
 	ma := a.copy(.row_major)
 	mb := b.copy(.row_major)

--- a/nn/internal/activation.v
+++ b/nn/internal/activation.v
@@ -2,11 +2,38 @@ module internal
 
 import math
 import vtl
+import vsl.compute as vsl_compute
+
+fn apply_unary_backend[T](x &vtl.Tensor[T], backend vsl_compute.Backend, strict bool, op string) !&vtl.Tensor[T] {
+	if backend == .cpu {
+		return error('cpu backend should use native path')
+	}
+	mut cctx := vsl_compute.new_context(backend)
+	cctx.strict = strict
+	x_f64 := x.copy(.row_major).as_f64().to_array()
+	y_f64 := match op {
+		'relu' { vsl_compute.relu(cctx, x_f64)! }
+		'sigmoid' { vsl_compute.sigmoid(cctx, x_f64)! }
+		'tanh' { vsl_compute.tanh(cctx, x_f64)! }
+		else { return error('unsupported unary op `${op}`') }
+	}
+
+	y_data := y_f64.map(vtl.cast[T](it))
+	mut out := vtl.from_1d[T](y_data, vtl.TensorData{})!
+	return out.reshape(x.shape)!
+}
 
 // tanh squashes a real-valued number to the range [-1, 1]
 @[inline]
 pub fn tanh[T](x &vtl.Tensor[T]) &vtl.Tensor[T] {
 	return x.tanh()
+}
+
+pub fn tanh_with_backend[T](x &vtl.Tensor[T], backend vsl_compute.Backend, strict bool) !&vtl.Tensor[T] {
+	if backend == .cpu {
+		return tanh[T](x)
+	}
+	return apply_unary_backend[T](x, backend, strict, 'tanh')
 }
 
 // deriv_tanh computes the derivative of tanh
@@ -25,6 +52,13 @@ pub fn sigmoid[T](x &vtl.Tensor[T]) &vtl.Tensor[T] {
 		// correct sigmoid: 1 / (1 + exp(-x))
 		return vtl.cast[T](1) / (vtl.cast[T](1) + vtl.cast[T](math.exp(-vtl.cast[f64](val))))
 	})
+}
+
+pub fn sigmoid_with_backend[T](x &vtl.Tensor[T], backend vsl_compute.Backend, strict bool) !&vtl.Tensor[T] {
+	if backend == .cpu {
+		return sigmoid[T](x)
+	}
+	return apply_unary_backend[T](x, backend, strict, 'sigmoid')
 }
 
 // deriv_sigmoid computes the derivative of sigmoid
@@ -47,6 +81,13 @@ pub fn relu[T](x &vtl.Tensor[T]) &vtl.Tensor[T] {
 		}
 		return val
 	})
+}
+
+pub fn relu_with_backend[T](x &vtl.Tensor[T], backend vsl_compute.Backend, strict bool) !&vtl.Tensor[T] {
+	if backend == .cpu {
+		return relu[T](x)
+	}
+	return apply_unary_backend[T](x, backend, strict, 'relu')
 }
 
 // deriv_relu computes the derivate of relu

--- a/nn/layers/batchnorm.v
+++ b/nn/layers/batchnorm.v
@@ -4,6 +4,8 @@ import vtl
 import vtl.autograd
 import vtl.nn.internal
 import vtl.nn.types
+import vsl.compute as vsl_compute
+import vsl.vulkan
 
 // BatchNorm1D normalizes a 2D input [batch, features].
 // Tracks running mean and variance for inference.
@@ -47,10 +49,41 @@ pub fn (layer &BatchNorm1DLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &BatchNorm1DLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
 	if !input.requires_grad {
 		// Inference path: use running stats
-		output := internal.batchnorm1d_forward[T](input.value, layer.gamma.value, layer.beta.value,
-			layer.running_mean, layer.running_var, layer.eps)!
+		output := if backend == .vulkan || backend == .auto {
+			mut dev := vulkan.new_device() or {
+				if strict && backend != .auto {
+					return err
+				}
+				unsafe { nil }
+			}
+			if isnil(dev) {
+				internal.batchnorm1d_forward[T](input.value, layer.gamma.value, layer.beta.value,
+					layer.running_mean, layer.running_var, layer.eps)!
+			} else {
+				defer {
+					dev.release()
+				}
+				norm := batchnorm1d_forward_vulkan[T](input.value, f32(layer.eps), dev) or {
+					if strict && backend != .auto {
+						return err
+					}
+					internal.batchnorm1d_forward[T](input.value, layer.gamma.value,
+						layer.beta.value, layer.running_mean, layer.running_var, layer.eps)!
+				}
+				norm.multiply[T](layer.gamma.value)!.add[T](layer.beta.value)!
+			}
+		} else {
+			if strict && backend != .cpu {
+				available := vsl_compute.available_backends().map(it.str()).join(', ')
+				return error('batchnorm1d(inference): backend `${backend}` unavailable for this build. available=[${available}]')
+			}
+			internal.batchnorm1d_forward[T](input.value, layer.gamma.value, layer.beta.value,
+				layer.running_mean, layer.running_var, layer.eps)!
+		}
 		return input.context.variable(output)
 	}
 	// Training path: compute batch stats

--- a/nn/layers/conv2d.v
+++ b/nn/layers/conv2d.v
@@ -4,6 +4,7 @@ import vtl
 import vtl.autograd
 import vtl.nn.internal
 import vtl.nn.types
+import vsl.compute as vsl_compute
 
 // Conv2D layer: 2D convolution over a 4D input tensor [batch, in_channels, H, W].
 // Produces [batch, out_channels, out_H, out_W] output.
@@ -66,8 +67,25 @@ pub fn (layer &Conv2DLayer[T]) forward(input &autograd.Variable[T]) !&autograd.V
 		dilation: layer.config.dilation
 		groups:   layer.config.groups
 	}
-	output := internal.conv2d_forward[T](input.value, layer.weight.value, layer.bias.value,
-		layer.kernel_size, cfg)!
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
+	output := if backend == .vulkan || backend == .auto {
+		conv2d_forward_vulkan[T](input.value, layer.weight.value, layer.bias.value,
+			layer.kernel_size, layer.config) or {
+			if strict && backend != .auto {
+				return err
+			}
+			internal.conv2d_forward[T](input.value, layer.weight.value, layer.bias.value,
+				layer.kernel_size, cfg)!
+		}
+	} else {
+		if strict && backend != .cpu {
+			available := vsl_compute.available_backends().map(it.str()).join(', ')
+			return error('conv2d: backend `${backend}` unavailable for this build. available=[${available}]')
+		}
+		internal.conv2d_forward[T](input.value, layer.weight.value, layer.bias.value,
+			layer.kernel_size, cfg)!
+	}
 	mut result := input.context.variable(output)
 
 	if input.requires_grad || layer.weight.requires_grad || layer.bias.requires_grad {

--- a/nn/layers/linear.v
+++ b/nn/layers/linear.v
@@ -38,7 +38,9 @@ pub fn (layer &LinearLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &LinearLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	mut output := la.matmul[T](input.value, layer.weights.value.t()!)!.add[T](layer.bias.value)!
+	mat := la.matmul_with_backend[T](input.value, layer.weights.value.t()!,
+		input.context.compute_backend, input.context.compute_strict)!
+	mut output := mat.add[T](layer.bias.value)!
 	mut result := input.context.variable(output)
 
 	if input.requires_grad || layer.weights.requires_grad || layer.bias.requires_grad {

--- a/nn/layers/maxpool.v
+++ b/nn/layers/maxpool.v
@@ -1,9 +1,12 @@
 module layers
 
+import vtl
 import vtl.autograd
 import vtl.nn.internal
 import vtl.nn.gates.layers
 import vtl.nn.types
+import vsl.compute as vsl_compute
+import vsl.vulkan
 
 // MaxPool2DLayer is a layer that implements the maxpooling operation.
 pub struct MaxPool2DLayer[T] {
@@ -41,8 +44,40 @@ pub fn (layer &MaxPool2DLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &MaxPool2DLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	max_indices, output := internal.maxpool2d[T](input.value, layer.kernel, layer.padding,
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
+	mut output := &vtl.Tensor[T](unsafe { nil })
+	if backend == .vulkan || backend == .auto {
+		mut dev := vulkan.new_device() or {
+			if strict && backend != .auto {
+				return err
+			}
+			unsafe { nil }
+		}
+		if !isnil(dev) {
+			defer {
+				dev.release()
+			}
+			output = maxpool2d_forward_vulkan[T](input.value, [layer.kernel[0], layer.kernel[1]], [
+				layer.stride[0],
+				layer.stride[1],
+			], [layer.padding[0], layer.padding[1]], dev) or {
+				if strict && backend != .auto {
+					return err
+				}
+				unsafe { nil }
+			}
+		}
+	}
+	max_indices, cpu_output := internal.maxpool2d[T](input.value, layer.kernel, layer.padding,
 		layer.stride)
+	if isnil(output) {
+		if strict && backend != .cpu && backend != .auto {
+			available := vsl_compute.available_backends().map(it.str()).join(', ')
+			return error('maxpool2d: backend `${backend}` unavailable for this build. available=[${available}]')
+		}
+		output = cpu_output
+	}
 	mut result := input.context.variable(output)
 
 	if input.requires_grad {

--- a/nn/layers/pool.v
+++ b/nn/layers/pool.v
@@ -4,6 +4,8 @@ import vtl
 import vtl.autograd
 import vtl.nn.internal
 import vtl.nn.types
+import vsl.compute as vsl_compute
+import vsl.vulkan
 
 // AveragePool2DLayer applies 2D average pooling over a 4D input.
 //
@@ -49,7 +51,39 @@ pub fn (layer &AveragePool2DLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &AveragePool2DLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	output := internal.avgpool2d_forward[T](input.value, layer.kernel, layer.padding, layer.stride)!
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
+	output := if backend == .vulkan || backend == .auto {
+		mut dev := vulkan.new_device() or {
+			if strict && backend != .auto {
+				return err
+			}
+			unsafe { nil }
+		}
+		if isnil(dev) {
+			internal.avgpool2d_forward[T](input.value, layer.kernel, layer.padding, layer.stride)!
+		} else {
+			defer {
+				dev.release()
+			}
+			avgpool2d_forward_vulkan[T](input.value, [layer.kernel[0], layer.kernel[1]], [
+				layer.stride[0],
+				layer.stride[1],
+			], [layer.padding[0], layer.padding[1]], dev) or {
+				if strict && backend != .auto {
+					return err
+				}
+				internal.avgpool2d_forward[T](input.value, layer.kernel, layer.padding,
+					layer.stride)!
+			}
+		}
+	} else {
+		if strict && backend != .cpu {
+			available := vsl_compute.available_backends().map(it.str()).join(', ')
+			return error('avgpool2d: backend `${backend}` unavailable for this build. available=[${available}]')
+		}
+		internal.avgpool2d_forward[T](input.value, layer.kernel, layer.padding, layer.stride)!
+	}
 	mut result := input.context.variable(output)
 	if input.requires_grad {
 		gate := avgpool2d_gate[T](input.value, layer.kernel, layer.padding, layer.stride)
@@ -111,7 +145,35 @@ pub fn (layer &GlobalAvgPool2DLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &GlobalAvgPool2DLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	output := internal.global_avgpool2d_forward[T](input.value)!
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
+	output := if backend == .vulkan || backend == .auto {
+		mut dev := vulkan.new_device() or {
+			if strict && backend != .auto {
+				return err
+			}
+			unsafe { nil }
+		}
+		if isnil(dev) {
+			internal.global_avgpool2d_forward[T](input.value)!
+		} else {
+			defer {
+				dev.release()
+			}
+			global_avgpool2d_forward_vulkan[T](input.value, dev) or {
+				if strict && backend != .auto {
+					return err
+				}
+				internal.global_avgpool2d_forward[T](input.value)!
+			}
+		}
+	} else {
+		if strict && backend != .cpu {
+			available := vsl_compute.available_backends().map(it.str()).join(', ')
+			return error('global_avgpool2d: backend `${backend}` unavailable for this build. available=[${available}]')
+		}
+		internal.global_avgpool2d_forward[T](input.value)!
+	}
 	mut result := input.context.variable(output)
 	if input.requires_grad {
 		gate := global_avgpool2d_gate[T](input.value)

--- a/nn/layers/relu.v
+++ b/nn/layers/relu.v
@@ -25,7 +25,8 @@ pub fn (_ &ReLULayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &ReLULayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	output := internal.relu[T](input.value)
+	output := internal.relu_with_backend[T](input.value, input.context.compute_backend,
+		input.context.compute_strict)!
 	mut result := input.context.variable(output)
 
 	if input.requires_grad {

--- a/nn/layers/sigmoid.v
+++ b/nn/layers/sigmoid.v
@@ -25,7 +25,8 @@ pub fn (_ &SigmoidLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &SigmoidLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	output := internal.sigmoid[T](input.value)
+	output := internal.sigmoid_with_backend[T](input.value, input.context.compute_backend,
+		input.context.compute_strict)!
 	mut result := input.context.variable(output)
 
 	if input.requires_grad {

--- a/nn/layers/softmax.v
+++ b/nn/layers/softmax.v
@@ -4,6 +4,9 @@ import vtl.autograd
 import vtl.nn.internal
 import vtl.nn.types
 import vtl.nn.gates.activation as activation_gates
+import vsl.compute as vsl_compute
+import vsl.vulkan
+import vtl.storage
 
 // SoftmaxLayer applies softmax activation over the last dimension of the input.
 // input shape: [..., n_classes]  →  output shape: [..., n_classes]
@@ -34,7 +37,35 @@ pub fn (layer &SoftmaxLayer[T]) variables() []&autograd.Variable[T] {
 pub fn (layer &SoftmaxLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
 	// Compute softmax along dim (-1 means last dim)
 	dim := if layer.dim == -1 { input.value.shape.len - 1 } else { layer.dim }
-	output := internal.softmax_forward[T](input.value, dim)!
+	backend := input.context.compute_backend
+	strict := input.context.compute_strict
+	output := if (backend == .vulkan || backend == .auto) && input.value.shape.len == 1 && dim == 0 {
+		mut dev := vulkan.new_device() or {
+			if strict && backend != .auto {
+				return err
+			}
+			unsafe { nil }
+		}
+		if isnil(dev) {
+			internal.softmax_forward[T](input.value, dim)!
+		} else {
+			defer {
+				dev.release()
+			}
+			softmax_forward_vulkan[T](input.value, storage.new_vulkan_params(dev)) or {
+				if strict && backend != .auto {
+					return err
+				}
+				internal.softmax_forward[T](input.value, dim)!
+			}
+		}
+	} else {
+		if strict && backend != .cpu && backend != .auto {
+			available := vsl_compute.available_backends().map(it.str()).join(', ')
+			return error('softmax: backend `${backend}` unsupported for this shape/dim. available=[${available}]')
+		}
+		internal.softmax_forward[T](input.value, dim)!
+	}
 	mut result := input.context.variable(output)
 
 	if input.requires_grad {

--- a/nn/layers/tanh.v
+++ b/nn/layers/tanh.v
@@ -25,7 +25,8 @@ pub fn (_ &TanhLayer[T]) variables() []&autograd.Variable[T] {
 }
 
 pub fn (layer &TanhLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
-	output := internal.tanh[T](input.value)
+	output := internal.tanh_with_backend[T](input.value, input.context.compute_backend,
+		input.context.compute_strict)!
 	mut result := input.context.variable(output)
 
 	if input.requires_grad {

--- a/nn/models/sequential.v
+++ b/nn/models/sequential.v
@@ -5,6 +5,7 @@ import vtl.autograd
 import vtl.nn.loss
 import vtl.nn.types
 import vtl.nn.layers
+import vsl.compute
 
 fn init() {
 	println(@MOD + ' module is a WIP and not yet functional')
@@ -200,6 +201,16 @@ pub fn (mut nn Sequential[T]) nll_loss() {
 // kl_div_loss sets the loss function to KL divergence loss.
 pub fn (mut nn Sequential[T]) kl_div_loss() {
 	nn.info.kl_div_loss()
+}
+
+// set_backend configures runtime backend preference for all forward passes in this model context.
+pub fn (mut nn Sequential[T]) set_backend(backend compute.Backend) {
+	nn.info.ctx.set_compute_backend(backend)
+}
+
+// set_backend_strict enables/disables strict runtime backend enforcement.
+pub fn (mut nn Sequential[T]) set_backend_strict(strict bool) {
+	nn.info.ctx.set_compute_strict(strict)
 }
 
 pub fn (mut nn Sequential[T]) forward(train &autograd.Variable[T]) !&autograd.Variable[T] {

--- a/runtime/backend.v
+++ b/runtime/backend.v
@@ -1,0 +1,48 @@
+module runtime
+
+import os
+import vsl.compute
+import vtl.autograd
+
+// ExecutionPolicy configures runtime backend selection.
+pub struct ExecutionPolicy {
+pub:
+	backend compute.Backend = .auto
+	strict  bool
+}
+
+// available_backends returns backends compiled in the current binary.
+pub fn available_backends() []compute.Backend {
+	return compute.available_backends()
+}
+
+// apply_policy applies runtime backend settings to an autograd context.
+pub fn apply_policy[T](mut ctx autograd.Context[T], policy ExecutionPolicy) {
+	ctx.set_compute_backend(policy.backend)
+	ctx.set_compute_strict(policy.strict)
+}
+
+// backend_from_string parses backend names used by env/config files.
+pub fn backend_from_string(value string) !compute.Backend {
+	match value.to_lower() {
+		'', 'auto' { return .auto }
+		'cpu' { return .cpu }
+		'vulkan', 'vk' { return .vulkan }
+		'vcl', 'opencl', 'ocl' { return .vcl }
+		'cuda' { return error('cuda backend is not available in this VTL build yet') }
+		else { return error('unknown backend `${value}`') }
+	}
+}
+
+// policy_from_env reads backend options from env vars.
+// - VTL_BACKEND: auto|cpu|vulkan|vcl|cuda
+// - VTL_BACKEND_STRICT: 1|true|yes to disable fallback
+pub fn policy_from_env() !ExecutionPolicy {
+	backend := backend_from_string(os.getenv_opt('VTL_BACKEND') or { '' })!
+	strict_value := os.getenv_opt('VTL_BACKEND_STRICT') or { '' }
+	strict := strict_value.to_lower() in ['1', 'true', 'yes', 'on']
+	return ExecutionPolicy{
+		backend: backend
+		strict:  strict
+	}
+}

--- a/runtime/backend_test.v
+++ b/runtime/backend_test.v
@@ -1,0 +1,37 @@
+module runtime
+
+import os
+import vsl.compute
+import vtl.autograd
+
+fn test_backend_from_string() {
+	assert backend_from_string('auto') or { compute.Backend.cpu } == .auto
+	assert backend_from_string('cpu') or { compute.Backend.auto } == .cpu
+	assert backend_from_string('vulkan') or { compute.Backend.auto } == .vulkan
+	assert backend_from_string('vcl') or { compute.Backend.auto } == .vcl
+	if _ := backend_from_string('invalid') {
+		assert false
+	}
+}
+
+fn test_apply_policy_updates_context() {
+	mut ctx := autograd.ctx[f64]()
+	apply_policy[f64](mut ctx, ExecutionPolicy{
+		backend: .vcl
+		strict:  true
+	})
+	assert ctx.compute_backend == .vcl
+	assert ctx.compute_strict
+}
+
+fn test_policy_from_env() {
+	os.setenv('VTL_BACKEND', 'cpu', true)
+	os.setenv('VTL_BACKEND_STRICT', '1', true)
+	defer {
+		os.unsetenv('VTL_BACKEND')
+		os.unsetenv('VTL_BACKEND_STRICT')
+	}
+	policy := policy_from_env() or { panic(err) }
+	assert policy.backend == .cpu
+	assert policy.strict
+}

--- a/runtime/layer_runtime_test.v
+++ b/runtime/layer_runtime_test.v
@@ -1,0 +1,43 @@
+module runtime
+
+import vsl.compute
+import vtl
+import vtl.autograd
+import vtl.nn.layers
+import vtl.nn.models
+
+fn test_sequential_backend_setters() {
+	mut ctx := autograd.ctx[f64]()
+	mut model := models.sequential_from_ctx[f64](ctx)
+	model.set_backend(.cpu)
+	model.set_backend_strict(true)
+	assert ctx.compute_backend == .cpu
+	assert ctx.compute_strict
+}
+
+fn test_softmax_strict_shape_guard() {
+	mut ctx := autograd.ctx[f32]()
+	ctx.set_compute_backend(.vulkan)
+	ctx.set_compute_strict(true)
+	x := vtl.from_2d[f32]([[1.0, 2.0], [3.0, 4.0]]) or { panic(err) }
+	input := ctx.variable(x)
+	l := layers.softmax_layer[f32](ctx, layers.SoftmaxLayerConfig{})
+	if _ := l.forward(input) {
+		assert false
+	} else {
+		assert err.msg().contains('unsupported')
+	}
+}
+
+fn test_relu_cpu_runtime_dispatch() {
+	mut ctx := autograd.ctx[f64]()
+	ctx.set_compute_backend(compute.Backend.cpu)
+	x := vtl.from_1d[f64]([-1.0, 0.0, 2.0], vtl.TensorData{}) or { panic(err) }
+	input := ctx.variable(x)
+	l := layers.relu_layer[f64](ctx, [3])
+	out := l.forward(input) or { panic(err) }
+	arr := out.value.to_array()
+	assert arr[0] == 0.0
+	assert arr[1] == 0.0
+	assert arr[2] == 2.0
+}


### PR DESCRIPTION
## What\n- add runtime backend policy support () via \n- store runtime backend preference in autograd context (, )\n- add model-level DX setters in  (, )\n- add backend-aware dispatch for:\n  -  ()\n  -  forward\n  - activation layers: , , \n  -  forward (Vulkan try + CPU fallback/strict error)\n  - pooling layers: , ,  (Vulkan try + CPU fallback/strict error)\n  -  (1D Vulkan path + fallback/strict behavior)\n  -  inference path (Vulkan normalization + CPU affine/fallback)\n- update MNIST example to read runtime policy from env\n- document runtime backend behavior and coverage in GPU tutorial\n- add runtime tests for policy parsing/application and layer/runtime behavior\n\n## Why\nThis enables selecting backend at runtime while keeping compile flags as capability gates, improving DX and aligning with backend-transparent model execution goals in #60.\n\n## Notes\n- local heavy test execution intentionally avoided per maintainer preference; CI is the source of truth\n- strict mode returns explicit errors when the requested backend cannot be used\n\nCloses #60 (runtime dispatch portion).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime backend selection supporting CPU, Vulkan, and OpenCL with automatic fallback or strict enforcement modes
  * Direct backend configuration API for models via `set_backend()` and `set_backend_strict()` methods
  * Environment variable control via `VTL_BACKEND` and `VTL_BACKEND_STRICT`

* **Documentation**
  * Tutorial on configuring and using compute backends

* **Tests**
  * Backend configuration and layer execution tests

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/80)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->