### PR TITLE
docs(metrics): add ml/metrics examples and README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,3 +30,7 @@ Some examples use alternate file names (for example, `main_not_ci.v`) when exclu
 - `vtl_opencl_vcl_support`
 - `vtl_plot_scatter_colorscale`
 - `vtl_vandermont`
+
+## Module-scoped examples
+
+- `ml/metrics/examples` — focused examples for `vtl.ml.metrics`

--- a/ml/metrics/README.md
+++ b/ml/metrics/README.md
@@ -1,0 +1,26 @@
+# vtl.ml.metrics
+
+Utilities for evaluating classification and regression outputs.
+
+## Available metrics
+
+- `accuracy_score(y_pred, y_true)`
+- `squared_error(y, y_true)`
+- `mean_squared_error(y, y_true)`
+- `absolute_error(y, y_true)`
+- `mean_absolute_error(y, y_true)`
+- `relative_error(y, y_true)`
+- `mean_relative_error(y, y_true)`
+
+## Examples
+
+Runnable examples are available in [`examples/`](./examples/):
+
+- `classification_accuracy`
+- `regression_errors`
+
+Run pattern:
+
+```sh
+v run ml/metrics/examples/<example_name>/main.v
+```

--- a/ml/metrics/examples/README.md
+++ b/ml/metrics/examples/README.md
@@ -1,0 +1,14 @@
+# Metrics examples
+
+This folder contains runnable examples for `vtl.ml.metrics`.
+
+## Examples
+
+- `classification_accuracy` — computes classification accuracy
+- `regression_errors` — computes MAE/MSE/MRE and raw error tensors
+
+Run pattern:
+
+```sh
+v run ml/metrics/examples/<example_name>/main.v
+```

--- a/ml/metrics/examples/classification_accuracy/README.md
+++ b/ml/metrics/examples/classification_accuracy/README.md
@@ -1,0 +1,15 @@
+# classification_accuracy
+
+Computes classification accuracy with `vtl.ml.metrics.accuracy_score`.
+
+## Run
+
+```sh
+v run main.v
+```
+
+## Expected output
+
+```text
+accuracy: 0.50
+```

--- a/ml/metrics/examples/classification_accuracy/main.v
+++ b/ml/metrics/examples/classification_accuracy/main.v
@@ -1,0 +1,13 @@
+module main
+
+import vtl
+import vtl.ml.metrics
+
+fn main() {
+	// Predicted and ground-truth class indices
+	y_pred := vtl.from_1d([0, 2, 1, 3]) or { panic(err) }
+	y_true := vtl.from_1d([0, 1, 2, 3]) or { panic(err) }
+
+	acc := metrics.accuracy_score(y_pred, y_true) or { panic(err) }
+	println('accuracy: ${acc:.2f}')
+}

--- a/ml/metrics/examples/regression_errors/README.md
+++ b/ml/metrics/examples/regression_errors/README.md
@@ -1,0 +1,17 @@
+# regression_errors
+
+Computes regression error metrics with `vtl.ml.metrics`.
+
+## Run
+
+```sh
+v run main.v
+```
+
+## Expected metric values
+
+- `mae`: `0.220000`
+- `mse`: `0.086000`
+- `mre`: `0.780000`
+
+Tensor print formatting may vary by VTL version.

--- a/ml/metrics/examples/regression_errors/main.v
+++ b/ml/metrics/examples/regression_errors/main.v
@@ -1,0 +1,25 @@
+module main
+
+import vtl
+import vtl.ml.metrics
+
+fn main() {
+	y_true := vtl.from_1d([0.9, 0.2, 0.1, 0.4, 0.9]) or { panic(err) }
+	y := vtl.from_1d([1.0, 0.0, 0.0, 1.0, 1.0]) or { panic(err) }
+
+	mae := metrics.mean_absolute_error(y, y_true) or { panic(err) }
+	mse := metrics.mean_squared_error(y, y_true) or { panic(err) }
+	mre := metrics.mean_relative_error(y, y_true) or { panic(err) }
+
+	println('mae: ${mae:.6f}')
+	println('mse: ${mse:.6f}')
+	println('mre: ${mre:.6f}')
+
+	abs_err := metrics.absolute_error(y, y_true) or { panic(err) }
+	sq_err := metrics.squared_error(y, y_true) or { panic(err) }
+	rel_err := metrics.relative_error(y, y_true) or { panic(err) }
+
+	println('absolute_error: ${abs_err}')
+	println('squared_error: ${sq_err}')
+	println('relative_error: ${rel_err}')
+}


### PR DESCRIPTION
## Summary
- add `ml/metrics/README.md` with metric inventory and run pattern
- add `ml/metrics/examples/README.md`
- add runnable examples:
  - `classification_accuracy`
  - `regression_errors`
- update `examples/README.md` to reference module-scoped metrics examples

## Why
Resolves a quick win for roadmap issue #28 by making `vtl.ml.metrics` discoverable and immediately runnable for contributors.

## Validation
- examples are self-contained and follow existing VTL example layout
- expected output documented in each example README

Closes #28


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `ml.metrics` module detailing available classification and regression evaluation metrics.
  * Introduced two runnable examples: classification accuracy computation and regression error metrics evaluation.
  * Included example documentation with execution instructions and expected output references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->