### PR TITLE
docs(examples): add vtl_broadcast_basics runnable example

### DIFF
--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -15,9 +15,9 @@ import vtl
 
 // From a V array
 t := vtl.from_2d([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])!
-println(t.shape)   // [2, 3]
-println(t.size)    // 6
-println(t.rank())  // 2
+println(t.shape) // [2, 3]
+println(t.size) // 6
+println(t.rank()) // 2
 ```
 
 Tensors are the fundamental data structure — n-dimensional arrays that support
@@ -33,8 +33,8 @@ import vtl
 a := vtl.from_1d([1.0, 2.0, 3.0])!
 b := vtl.from_1d([4.0, 5.0, 6.0])!
 
-c := a.add(b)!        // [5, 7, 9]
-d := a.multiply(b)!   // [4, 10, 18]
+c := a.add(b)! // [5, 7, 9]
+d := a.multiply(b)! // [4, 10, 18]
 println(c)
 println(d)
 ```
@@ -58,10 +58,10 @@ ctx := autograd.ctx[f64]()
 x := ctx.variable(vtl.from_1d([3.0])!)
 y := ctx.variable(vtl.from_1d([2.0])!)
 
-mut z := x.pow(y)!   // z = 3^2 = 9
+mut z := x.pow(y)! // z = 3^2 = 9
 z.backprop()!
 
-println(x.grad)       // [6.0] — dz/dx = 2*x = 6
+println(x.grad) // [6.0] — dz/dx = 2*x = 6
 ```
 
 This is how neural networks learn — the loss is backpropagated through

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,7 @@ Some examples use alternate file names (for example, `main_not_ci.v`) when exclu
 - `nn_regression_sine`
 - `nn_simple_two_layer`
 - `nn_xor`
+- `vtl_broadcast_basics`
 - `vtl_basic_usage`
 - `vtl_opencl_vcl_support`
 - `vtl_plot_scatter_colorscale`

--- a/examples/vtl_broadcast_basics/README.md
+++ b/examples/vtl_broadcast_basics/README.md
@@ -1,0 +1,18 @@
+# vtl_broadcast_basics
+
+Demonstrates implicit broadcasting in VTL using:
+
+- column vector `[4, 1]`
+- row vector `[1, 3]`
+- scalar broadcasting
+
+## Run
+
+```sh
+v run main.v
+```
+
+## Expected behavior
+
+- `col + row` produces a `[4, 3]` tensor
+- `grid + scalar` shifts all values by the scalar

--- a/examples/vtl_broadcast_basics/main.v
+++ b/examples/vtl_broadcast_basics/main.v
@@ -1,0 +1,22 @@
+module main
+
+import vtl
+
+fn main() {
+	// Row vector [1, 3]
+	row := vtl.from_2d([[10, 20, 30]]) or { panic(err) }
+	// Column vector [4, 1]
+	col := vtl.from_2d([[1], [2], [3], [4]]) or { panic(err) }
+
+	grid := col.add(row) or { panic(err) }
+
+	println('row shape: ${row.shape}')
+	println('col shape: ${col.shape}')
+	println('grid shape: ${grid.shape}')
+	println(grid)
+
+	// Scalar broadcasting
+	shifted := grid.add_scalar(5) or { panic(err) }
+	println('shifted (+5):')
+	println(shifted)
+}


### PR DESCRIPTION
## Summary
- add new runnable example: `examples/vtl_broadcast_basics/main.v`
- add example documentation: `examples/vtl_broadcast_basics/README.md`
- register the new example in `examples/README.md`

## Why
Addresses quick-win issue #26 by expanding example coverage with a focused broadcasting walkthrough.

## Validation
- example follows existing VTL example layout (`main.v` + `README.md`)
- behavior is documented with expected tensor shape outcomes

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new broadcasting example with comprehensive documentation for learning VTL's implicit broadcasting capabilities in depth.
  * Demonstrates practical column vector, row vector, and scalar broadcasting operations with clear examples.
  * Includes fully runnable code with error handling and detailed expected output descriptions to help users effectively understand and apply broadcasting mechanics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->