### PR TITLE
feat(datasets): add iris dataset loader with runnable example

### DIFF
--- a/datasets/README.md
+++ b/datasets/README.md
@@ -6,3 +6,10 @@ We expose the following datasets:
 
 - **Mnist**: A dataset of handwritten digits.
 - **Imdb**: A dataset of IMDB reviews for sentiment analysis.
+- **Iris**: A tabular dataset for 3-class flower classification.
+
+## API
+
+- `load_mnist()`
+- `load_imdb()`
+- `load_iris()`

--- a/datasets/iris.v
+++ b/datasets/iris.v
@@ -1,0 +1,87 @@
+module datasets
+
+import os
+import vtl
+
+pub const iris_file_name = 'iris.data'
+pub const iris_base_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/iris/'
+
+pub const iris_features_count = 4
+
+// IrisDataset is the classic Iris classification dataset.
+//
+// Features are shape [150, 4] with columns:
+// - sepal length
+// - sepal width
+// - petal length
+// - petal width
+//
+// Labels are encoded as:
+// - 0 => Iris-setosa
+// - 1 => Iris-versicolor
+// - 2 => Iris-virginica
+pub struct IrisDataset {
+pub:
+	features &vtl.Tensor[f64] = unsafe { nil }
+	labels   &vtl.Tensor[int] = unsafe { nil }
+}
+
+fn iris_label_to_int(label string) !int {
+	return match label {
+		'Iris-setosa' { 0 }
+		'Iris-versicolor' { 1 }
+		'Iris-virginica' { 2 }
+		else { return error('unknown iris label: ${label}') }
+	}
+}
+
+// load_iris downloads (if needed) and parses the UCI Iris dataset.
+pub fn load_iris() !IrisDataset {
+	dataset_path := download_dataset(
+		dataset:          'iris'
+		baseurl:          iris_base_url
+		compressed:       false
+		uncompressed_dir: iris_file_name
+		file:             iris_file_name
+	)!
+
+	content := os.read_file(dataset_path)!
+	lines := content.split_into_lines()
+
+	mut features := []f64{}
+	mut labels := []int{}
+
+	for line in lines {
+		trimmed := line.trim_space()
+		if trimmed == '' {
+			continue
+		}
+
+		parts := trimmed.split(',')
+		if parts.len != 5 {
+			return error('invalid iris row: expected 5 columns, got ${parts.len}')
+		}
+
+		for i in 0 .. iris_features_count {
+			features << parts[i].f64()
+		}
+
+		labels << iris_label_to_int(parts[4])!
+	}
+
+	if labels.len == 0 {
+		return error('iris dataset is empty')
+	}
+
+	if features.len != labels.len * iris_features_count {
+		return error('invalid iris tensor shape: features=${features.len}, labels=${labels.len}')
+	}
+
+	features_tensor := vtl.from_1d(features)!.reshape([-1, iris_features_count])!
+	labels_tensor := vtl.from_1d(labels)!
+
+	return IrisDataset{
+		features: features_tensor
+		labels:   labels_tensor
+	}
+}

--- a/datasets/iris_test.v
+++ b/datasets/iris_test.v
@@ -1,0 +1,10 @@
+// vtest flaky
+// vtest retry: 3
+module datasets
+
+fn test_iris() {
+	iris := load_iris()!
+
+	assert iris.features.shape == [150, 4]
+	assert iris.labels.shape == [150]
+}

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -15,9 +15,9 @@ import vtl
 
 // From a V array
 t := vtl.from_2d([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])!
-println(t.shape)   // [2, 3]
-println(t.size)    // 6
-println(t.rank())  // 2
+println(t.shape) // [2, 3]
+println(t.size) // 6
+println(t.rank()) // 2
 ```
 
 Tensors are the fundamental data structure — n-dimensional arrays that support
@@ -33,8 +33,8 @@ import vtl
 a := vtl.from_1d([1.0, 2.0, 3.0])!
 b := vtl.from_1d([4.0, 5.0, 6.0])!
 
-c := a.add(b)!        // [5, 7, 9]
-d := a.multiply(b)!   // [4, 10, 18]
+c := a.add(b)! // [5, 7, 9]
+d := a.multiply(b)! // [4, 10, 18]
 println(c)
 println(d)
 ```
@@ -58,10 +58,10 @@ ctx := autograd.ctx[f64]()
 x := ctx.variable(vtl.from_1d([3.0])!)
 y := ctx.variable(vtl.from_1d([2.0])!)
 
-mut z := x.pow(y)!   // z = 3^2 = 9
+mut z := x.pow(y)! // z = 3^2 = 9
 z.backprop()!
 
-println(x.grad)       // [6.0] — dz/dx = 2*x = 6
+println(x.grad) // [6.0] — dz/dx = 2*x = 6
 ```
 
 This is how neural networks learn — the loss is backpropagated through

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,6 +19,7 @@ Some examples use alternate file names (for example, `main_not_ci.v`) when exclu
 
 - `autograd_backprop`
 - `datasets_imdb`
+- `datasets_iris`
 - `datasets_mnist`
 - `nn_autoencoder_simple`
 - `nn_mnist`

--- a/examples/datasets_iris/README.md
+++ b/examples/datasets_iris/README.md
@@ -1,0 +1,24 @@
+# Iris Dataset Example
+
+This example demonstrates loading and inspecting the classic Iris dataset via `vtl.datasets`.
+
+## What it covers
+
+- Dataset download/loading (`datasets.load_iris`)
+- Feature/label tensor shapes
+- First-row inspection
+- Class distribution summary (0/1/2)
+
+## Run
+
+```sh
+v run examples/datasets_iris/main.v
+```
+
+## Notes
+
+- First run may download the dataset file.
+- Labels are encoded as:
+  - `0`: Iris-setosa
+  - `1`: Iris-versicolor
+  - `2`: Iris-virginica

--- a/examples/datasets_iris/main.v
+++ b/examples/datasets_iris/main.v
@@ -1,0 +1,24 @@
+module main
+
+import vtl
+import vtl.datasets
+
+fn main() {
+	iris := datasets.load_iris() or { panic(err) }
+
+	assert iris.features.shape == [150, 4]
+	assert iris.labels.shape == [150]
+
+	println('features shape: ${iris.features.shape}')
+	println('labels shape: ${iris.labels.shape}')
+
+	first_row := iris.features.slice([0, 1], [0, 4]) or { panic(err) }
+	println('first feature row: ${first_row}')
+
+	// Class distribution summary
+	for class_id in [0, 1, 2] {
+		class_mask := iris.labels.equal(vtl.tensor(class_id, [150])) or { panic(err) }
+		count := class_mask.to_array[bool]().filter(it).len
+		println('class ${class_id} count: ${count}')
+	}
+}


### PR DESCRIPTION
## Summary
- add new dataset loader: `datasets.load_iris()`
- add new dataset struct: `datasets.IrisDataset`
- add parser/label encoder for UCI Iris dataset (`iris.data`)
- add coverage test: `datasets/iris_test.v`
- add runnable example: `examples/datasets_iris/main.v` + README
- update docs indexes:
  - `datasets/README.md`
  - `examples/README.md`

## Why
Addresses quick-win issue #27 by adding a widely used tabular classification dataset with a complete loader + test + runnable usage example.

## Validation
- loader returns expected shapes:
  - features: `[150, 4]`
  - labels: `[150]`
- labels are encoded consistently:
  - `0`: Iris-setosa
  - `1`: Iris-versicolor
  - `2`: Iris-virginica
- example demonstrates dataset loading and class distribution summary.

Closes #27


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Iris dataset, including loading and parsing into feature and label tensors.

* **Documentation**
  * Updated dataset docs to list the Iris dataset and its usage.
  * Refined tutorial formatting for consistent example output.

* **Examples**
  * Added an Iris example demonstrating loading, inspecting shapes, and per-class counts.

* **Tests**
  * Added a test to verify expected feature/label shapes for the Iris dataset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vlang/vtl/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->