### PR TITLE
feat(nn): serialization round-trip + CIFAR-10 checkpoints (#87)

### DIFF
--- a/benchmarks/util/bench_util.v
+++ b/benchmarks/util/bench_util.v
@@ -24,7 +24,7 @@ pub fn gflops_gemm(m int, n int, k int, time_ms f64) f64 {
 	if time_ms <= 0.0 {
 		return 0.0
 	}
-	ops := f64(2 * m * n * k)
+	ops := 2.0 * f64(m) * f64(n) * f64(k)
 	sec := time_ms / 1000.0
 	return ops / sec / 1_000_000_000.0
 }

--- a/examples/nn_cifar10/main.v
+++ b/examples/nn_cifar10/main.v
@@ -1,5 +1,6 @@
 module main
 
+import os
 import vtl
 import vtl.autograd
 import vtl.datasets
@@ -11,6 +12,8 @@ import vtl.nn.optimizers
 const batch_size = 64
 const epochs = 1
 const learning_rate = 0.001
+const checkpoint_dir = 'checkpoints'
+const checkpoint_every_epochs = 1
 
 fn create_cnn_cifar10[T](ctx &autograd.Context[T]) &models.Sequential[T] {
 	mut model := models.sequential_from_ctx[T](ctx)
@@ -61,8 +64,48 @@ fn calculate_accuracy[T](predictions &vtl.Tensor[T], targets &vtl.Tensor[T]) f64
 	return f64(correct) / f64(sample_count) * 100.0
 }
 
+fn wants_resume() bool {
+	for arg in os.args {
+		if arg == '--resume' {
+			return true
+		}
+	}
+	return false
+}
+
+fn checkpoint_path(epoch int) string {
+	return '${checkpoint_dir}/cifar10_epoch_${epoch}.json'
+}
+
+fn latest_checkpoint() !string {
+	if !os.exists(checkpoint_dir) {
+		return error('no checkpoint directory')
+	}
+	mut best_epoch := -1
+	mut best_path := ''
+	entries := os.ls(checkpoint_dir)!
+	for entry in entries {
+		if !entry.ends_with('.json') {
+			continue
+		}
+		if entry.starts_with('cifar10_epoch_') {
+			suffix := entry.all_after('cifar10_epoch_').all_before('.json')
+			epoch := suffix.int()
+			if epoch > best_epoch {
+				best_epoch = epoch
+				best_path = os.join_path(checkpoint_dir, entry)
+			}
+		}
+	}
+	if best_path == '' {
+		return error('no checkpoint files found')
+	}
+	return best_path
+}
+
 fn main() {
 	ctx := autograd.ctx[f64]()
+	os.mkdir_all(checkpoint_dir) or {}
 
 	println('Loading CIFAR-10 dataset...')
 	ds := datasets.load_cifar10_with_config(datasets.Cifar10Config{
@@ -84,6 +127,15 @@ fn main() {
 	})
 	optimizer.build_params(model.info.layers)
 	println('Model built successfully!')
+
+	mut start_epoch := 0
+	if wants_resume() {
+		path := latest_checkpoint()!
+		model.load_weights(path)!
+		epoch_meta, loss_meta := models.Sequential.load_checkpoint[f64](path)!
+		start_epoch = epoch_meta
+		println('Resumed from ${path} (epoch ${epoch_meta}, loss ${loss_meta:.6f})')
+	}
 
 	// Training DataLoader with lockstep features + labels
 	mut train_dl := datasets.new_data_loader_with_labels[f64](ds.train_features, ds.train_labels, datasets.DataLoaderConfig{
@@ -109,7 +161,7 @@ fn main() {
 	mut val_losses := []f64{}
 	mut val_accuracies := []f64{}
 
-	for epoch := 0; epoch < epochs; epoch++ {
+	for epoch := start_epoch; epoch < epochs; epoch++ {
 		println('\n========================================')
 		println('Epoch ${epoch + 1}/${epochs}')
 		println('========================================')
@@ -171,6 +223,12 @@ fn main() {
 		val_accuracies << val_accuracy
 
 		train_dl.reset()
+
+		if (epoch + 1) % checkpoint_every_epochs == 0 {
+			ckpt := checkpoint_path(epoch + 1)
+			model.save_checkpoint(ckpt, epoch + 1, avg_loss)!
+			println('    Checkpoint saved: ${ckpt}')
+		}
 	}
 
 	println('\n========================================')

--- a/nn/models/serialization_test.v
+++ b/nn/models/serialization_test.v
@@ -2,6 +2,7 @@ module models
 
 import os
 import json
+import math
 import vtl
 import vtl.nn.types
 import vtl.nn.layers
@@ -517,6 +518,69 @@ fn test_layer_norm_serialization() {
 	// gamma and beta should be present
 	assert 'gamma' in model.layer_data[1].weights
 	assert 'beta' in model.layer_data[1].weights
+}
+
+fn test_round_trip_weights_allclose_1e9() {
+	test_dir := setup_test_dir()
+	defer {
+		cleanup_test_dir()
+	}
+
+	mut nn1 := sequential_with_layers[f64]([]types.Layer[f64]{})
+	nn1.input([1, 4])
+	nn1.linear(3)
+	nn1.relu()
+	nn1.linear(2)
+
+	vars := nn1.info.layers[1].variables()
+	mut w := vars[0].value
+	mut b := vars[1].value
+	for i in 0 .. w.size() {
+		w.set_nth(i, vtl.cast[f64](f64(i) * 0.11 + 0.01))
+	}
+	for i in 0 .. b.size() {
+		b.set_nth(i, vtl.cast[f64](f64(i) * 0.07))
+	}
+
+	path := '${test_dir}/roundtrip_allclose.json'
+	nn1.save(path)!
+
+	mut nn2 := sequential_with_layers[f64]([]types.Layer[f64]{})
+	nn2.input([1, 4])
+	nn2.linear(3)
+	nn2.relu()
+	nn2.linear(2)
+	nn2.load_weights(path)!
+
+	assert weights_allclose(nn1, nn2, 1e-9), 'round-trip weights differ beyond 1e-9'
+}
+
+fn weights_allclose(a &Sequential[f64], b &Sequential[f64], tol f64) bool {
+	if a.info.layers.len != b.info.layers.len {
+		return false
+	}
+	for i, layer in a.info.layers {
+		vars_a := layer.variables()
+		vars_b := b.info.layers[i].variables()
+		if vars_a.len != vars_b.len {
+			return false
+		}
+		for j in 0 .. vars_a.len {
+			va := vars_a[j].value
+			vb := vars_b[j].value
+			if va.size() != vb.size() {
+				return false
+			}
+			for k in 0 .. va.size() {
+				da := f64(va.get_nth(k))
+				db := f64(vb.get_nth(k))
+				if math.abs(da - db) > tol {
+					return false
+				}
+			}
+		}
+	}
+	return true
 }
 
 fn test_readme_example() {


### PR DESCRIPTION
## Summary

- `test_round_trip_weights_allclose_1e9` in `serialization_test.v`
- CIFAR-10 example: `save_checkpoint` each epoch, `--resume` loads latest weights
- GFLOPS helper int-overflow fix in `bench_util.v`

## Test plan

- [x] `VJOBS=1 v test vtl/nn/models/serialization_test.v`

Closes #87


Made with [Cursor](https://cursor.com)