### PR TITLE
feat(examples): nn_cifar10_cuda + ROADMAP sync + benchmark PR comment

### DIFF
--- a/.github/workflows/benchmark-pr-comment.yml
+++ b/.github/workflows/benchmark-pr-comment.yml
@@ -1,0 +1,47 @@
+name: vs NumPy PR comment
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'benchmarks/**'
+      - '.github/workflows/benchmark-pr-comment.yml'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: vtl
+
+      - uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
+
+      - name: Install deps
+        run: |
+          v install vsl
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y libopenblas-dev liblapacke-dev gfortran python3 python3-numpy
+
+      - name: Install module
+        run: cp -rf ./vtl ~/.vmodules/vtl
+
+      - name: Run vs NumPy harness
+        run: |
+          cd ~/.vmodules
+          {
+            echo '## VTL vs NumPy (CPU matmul via vsl.la)'
+            v -d vsl_blas_cblas run vtl/benchmarks/vs_numpy/matmul_bench.v
+            v run vtl/benchmarks/vs_numpy/conv2d_bench.v
+          } 2>&1 | tee vs_numpy_pr.md
+
+      - name: Post sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: vtl-vs-numpy
+          path: ~/.vmodules/vs_numpy_pr.md

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,26 +59,20 @@
 - [x] `datasets/dataloader.v` — `DataLoader[T]` with batching, shuffle, labels ([issue #86](https://github.com/vlang/vtl/issues/86) closed)
 - [x] Used in `nn_cifar10_*` examples
 
-### Phase C — Model Serialization Polish
-- [x] `nn/models/serialization.v` + `serialization_test.v` (round-trip, checkpoints)
-- [ ] Integrate checkpoint save/load into CIFAR example — [issue #87](https://github.com/vlang/vtl/issues/87)
+### Phase C — Model Serialization Polish — closed [#87](https://github.com/vlang/vtl/issues/87)
+- [x] `serialization_test.v` round-trip at 1e-9
+- [x] `nn_cifar10/main.v` checkpoints + `--resume` (PR #95)
 
-### Phase C2 — VTL ↔ VSL GPU Integration (ML launch critical path)
-- [ ] Wire `LinearLayer` to CUDA — [issue #89](https://github.com/vlang/vtl/issues/89)
-- [ ] Wire `Conv2D` to `vsl.cuda` cuDNN — [issue #90](https://github.com/vlang/vtl/issues/90)
-- [ ] Device-resident autograd / training loop — [issue #91](https://github.com/vlang/vtl/issues/91)
+### Phase C2 — VTL ↔ VSL GPU Integration — closed [#89](https://github.com/vlang/vtl/issues/89)–[#91](https://github.com/vlang/vtl/issues/91) (PR #93)
+- [x] CUDA Linear, Conv2D, DeviceSession (opt-in `VTL_USE_CUDA=1`, `-d cuda`)
 
-### Phase D — Numpy Benchmark Suite — [issue #88](https://github.com/vlang/vtl/issues/88)
-- [ ] `vtl/benchmarks/` directory with:
-  - `matmul_benchmark.v` — VTL vs NumPy: matrix multiplication (CPU + CUDA)
-  - `conv2d_benchmark.v` — VTL vs NumPy: 2D convolution
-  - `autograd_benchmark.v` — VTL vs PyTorch: backprop overhead
-  - `nn_training_benchmark.v` — end-to-end training step (VTL vs PyTorch)
-- [ ] CI benchmark runner (GH Actions) with comparison vs NumPy baseline
-- [ ] Report speedup/slowdown metrics in PRs
+### Phase D — Numpy Benchmark Suite — closed [#88](https://github.com/vlang/vtl/issues/88) (PR #94)
+- [x] `benchmarks/vs_numpy/` matmul + conv2d + `bench_util`
+- [ ] `autograd_bench.v` MLP backprop; PyTorch baseline
+- [x] PR comment workflow (`benchmark-pr-comment.yml`, PR #96)
 
 ### Phase E — Example Consolidation
-- [ ] `nn_cifar10_cuda` variant with explicit CUDA device selection
+- [x] `nn_cifar10_cuda` — opt-in CUDA smoke (`VTL_USE_CUDA=1`, `-d cuda`)
 - [ ] `nn_cifar10_vulkan` variant using Vulkan backend
 - [ ] All variants should pass `v check-md -fix -hide-warnings` from `~/.vmodules`
 
@@ -95,11 +89,11 @@
 | [#60](https://github.com/vlang/vtl/issues/60) | Phase 3: VSL Integration + CUDA | 🟢 Done | |
 | [#59](https://github.com/vlang/vtl/issues/59) | Phase 2: Forward Pass on GPU | 🟢 Done | |
 | [#58](https://github.com/vlang/vtl/issues/58) | Phase 1: Vulkan Compute Foundation | 🟢 Done | |
-| [#89](https://github.com/vlang/vtl/issues/89) | Wire LinearLayer to CUDA | 🔴 P0 | ML launch |
-| [#90](https://github.com/vlang/vtl/issues/90) | Wire Conv2D to vsl.cuda | 🔴 P0 | ML launch |
-| [#91](https://github.com/vlang/vtl/issues/91) | Device-resident autograd | 🔴 P0 | ML launch |
-| [#88](https://github.com/vlang/vtl/issues/88) | vs NumPy/PyTorch benchmarks | 🔴 High | |
-| [#87](https://github.com/vlang/vtl/issues/87) | Checkpointing in CIFAR example | 🟡 Medium | |
+| [#89](https://github.com/vlang/vtl/issues/89) | Wire LinearLayer to CUDA | 🟢 Done | #93 |
+| [#90](https://github.com/vlang/vtl/issues/90) | Wire Conv2D to vsl.cuda | 🟢 Done | #93 |
+| [#91](https://github.com/vlang/vtl/issues/91) | Device-resident autograd | 🟢 Done | #93 |
+| [#88](https://github.com/vlang/vtl/issues/88) | vs NumPy benchmarks | 🟢 Done | #94 |
+| [#87](https://github.com/vlang/vtl/issues/87) | Checkpointing in CIFAR | 🟢 Done | #95 |
 | [#52](https://github.com/vlang/vtl/issues/52) | Tracel-AI/Burn reference | 🟢 Research | |
 | [#43](https://github.com/vlang/vtl/issues/43) | `stats.to_array` performance fix | 🔴 High | Prevent allocation overhead |
 | [#40](https://github.com/vlang/vtl/issues/40) | YOLO for autograd gates | 🟡 Medium | Loop-once pattern for gates |

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -10,15 +10,12 @@ Detailed file-level roadmap: [ROADMAP.md](../ROADMAP.md) in this repo.
 
 | Priority | Issue | Topic |
 |----------|-------|--------|
-| P0 | [#89](https://github.com/vlang/vtl/issues/89) | Wire `LinearLayer` to CUDA — **PR #93** |
-| P0 | [#90](https://github.com/vlang/vtl/issues/90) | Wire `Conv2D` to `vsl.cuda` — **PR #93** |
-| P0 | [#91](https://github.com/vlang/vtl/issues/91) | DeviceSession staging — **PR #93** |
-| P1 | [#88](https://github.com/vlang/vtl/issues/88) | vs NumPy/PyTorch benchmarks |
-| P1 | [#87](https://github.com/vlang/vtl/issues/87) | CIFAR checkpoint example |
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
+| — | — | `nn_cifar10_cuda` example added (opt-in GPU smoke) |
+| P2 | follow-up | Benchmark PR comments + PyTorch baselines (#88 scripts done) |
 
-VSL-side blockers: [vlang/vsl#280](https://github.com/vlang/vsl/issues/280),
-[#281](https://github.com/vlang/vsl/issues/281), [#282](https://github.com/vlang/vsl/issues/282).
+**Done (2026-05-31):** #89–#91 (PR #93), #88 (PR #94), #87 (PR #95).  
+**VSL done:** #280, #281, #282.
 
 ## Local development
 
@@ -32,8 +29,9 @@ cd ~/.vmodules
 # Smoke (avoid full v test vtl on low-RAM machines)
 v test vtl/nn vtl/datasets
 v run vtl/examples/nn_cifar10_tiny_synth/main.v
-# CUDA training (when wired — issue #89+)
-# v -d cuda run vtl/examples/nn_cifar10_tiny/main.v
+# CUDA Linear/Conv2D (opt-in, PR #93)
+# VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_tiny_synth/main.v
+# VTL_USE_CUDA=1 v -d cuda test vtl/nn/layers/linear_cuda_test.v
 ```
 
 ## CI recommendation

--- a/examples/nn_cifar10_cuda/README.md
+++ b/examples/nn_cifar10_cuda/README.md
@@ -1,0 +1,18 @@
+# nn_cifar10_cuda
+
+Tiny synthetic CIFAR-shaped pipeline for **opt-in** GPU linear forward.
+
+## Run (local, CUDA build)
+
+```bash
+export VTL_USE_CUDA=1
+v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
+```
+
+Without `VTL_USE_CUDA`, the example still runs on CPU (same weights path as `nn_cifar10_tiny_synth`).
+
+## Notes
+
+- Not executed in default CI (CUDA link + memory).
+- For full CIFAR-10 + checkpoints see `examples/nn_cifar10/`.
+- Device session staging: `autograd/device_session_test.v` with `VTL_TEST_CUDA=1`.

--- a/examples/nn_cifar10_cuda/main.v
+++ b/examples/nn_cifar10_cuda/main.v
@@ -1,0 +1,59 @@
+module main
+
+import vtl
+import vtl.autograd
+import vtl.nn.layers
+import vtl.nn.models
+import vtl.nn.optimizers
+
+// GPU smoke test: same tiny synthetic pipeline as nn_cifar10_tiny_synth, but documents
+// opt-in CUDA for Linear forward (Conv2D when model includes conv layers).
+//
+//   VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
+//
+// CI does not run this example (requires CUDA toolchain + GPU libs).
+
+const batch_size = 4
+const epochs = 1
+const batches = 2
+
+fn main() {
+	use_cuda := layers.cuda_linear_enabled()
+	println('nn_cifar10_cuda: VTL_USE_CUDA=${use_cuda} (build with -d cuda for GPU forward)')
+
+	ctx := autograd.ctx[f64]()
+	mut model := models.sequential_from_ctx[f64](ctx)
+	model.input([3, 32, 32])
+	model.flatten()
+	model.linear(10)
+	model.softmax()
+	model.mse_loss()
+
+	mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
+		learning_rate: 0.001
+	})
+	opt.build_params(model.info.layers)
+
+	for epoch := 0; epoch < epochs; epoch++ {
+		for b := 0; b < batches; b++ {
+			x_tensor := vtl.ones[f64]([batch_size, 3, 32, 32])
+			y_tensor := vtl.zeros[f64]([batch_size, 10])
+
+			x := ctx.variable(x_tensor, requires_grad: true)
+			pred := model.forward(x)!
+			mut loss := model.loss(pred, y_tensor)!
+			loss_val := loss.value.get([0])
+
+			loss.backprop()!
+			opt.update()!
+
+			println('epoch ${epoch + 1}/${epochs} batch ${b + 1}/${batches} loss=${loss_val:.4f}')
+		}
+	}
+
+	if use_cuda {
+		println('CUDA opt-in training smoke OK ✅')
+	} else {
+		println('CPU path OK (set VTL_USE_CUDA=1 -d cuda for GPU) ✅')
+	}
+}


### PR DESCRIPTION
## Summary
- Sync `ROADMAP.md` / `ML_ROADMAP.md` for closed #87–#91.
- Add `examples/nn_cifar10_cuda` (opt-in `VTL_USE_CUDA=1`, `-d cuda`).
- Add `benchmark-pr-comment.yml` for sticky vs NumPy output on benchmark PRs.

## Test plan
- [x] `v run vtl/examples/nn_cifar10_cuda/main.v` (CPU path)
- [ ] CI fmt-check + benchmark comment workflow


Made with [Cursor](https://cursor.com)