### PR TITLE
feat(examples): READMEs for CI smokes; CUDA conv2d smoke

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,7 +77,7 @@
 - [x] `nn_cifar10_cuda` — opt-in CUDA smoke (`VTL_USE_CUDA=1`, `-d cuda`)
 - [x] `nn_cifar10_vulkan` — f32 smoke + `linear_forward_vulkan` check
 - [x] Root `README.md` passes `v check-md -hide-warnings`
-- [ ] All example READMEs pass `v check-md -hide-warnings`
+- [x] All example READMEs pass `v check-md -hide-warnings`
 
 ### Phase F — GPU training loop (follow-up to #91)
 - [x] Phase 1: `DeviceSession` buffer reuse; CUDA forward for Linear/Conv2D

--- a/examples/nn_cifar10_cuda/README.md
+++ b/examples/nn_cifar10_cuda/README.md
@@ -1,6 +1,6 @@
 # nn_cifar10_cuda
 
-Tiny synthetic CIFAR-shaped pipeline for **opt-in** GPU linear forward.
+Tiny synthetic CIFAR-shaped pipeline for **opt-in** GPU Conv2D + Linear forward.
 
 ## Run (local, CUDA build)
 

--- a/examples/nn_cifar10_cuda/main.v
+++ b/examples/nn_cifar10_cuda/main.v
@@ -6,8 +6,7 @@ import vtl.nn.layers
 import vtl.nn.models
 import vtl.nn.optimizers
 
-// GPU smoke test: same tiny synthetic pipeline as nn_cifar10_tiny_synth, but documents
-// opt-in CUDA for Linear forward (Conv2D when model includes conv layers).
+// GPU smoke: tiny synthetic CIFAR + Conv2D + Linear on CUDA when opted in.
 //
 //   VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 //
@@ -19,11 +18,15 @@ const batches = 2
 
 fn main() {
 	use_cuda := layers.cuda_linear_enabled()
-	println('nn_cifar10_cuda: VTL_USE_CUDA=${use_cuda} (build with -d cuda for GPU forward)')
+	println('nn_cifar10_cuda: VTL_USE_CUDA=${use_cuda} (-d cuda build for GPU forward)')
 
 	ctx := autograd.ctx[f64]()
 	mut model := models.sequential_from_ctx[f64](ctx)
 	model.input([3, 32, 32])
+	model.conv2d(3, 8, [3, 3], layers.Conv2DConfig{
+		padding: [1, 1]
+	})
+	model.relu()
 	model.flatten()
 	model.linear(10)
 	model.softmax()

--- a/examples/nn_cifar10_safe/README.md
+++ b/examples/nn_cifar10_safe/README.md
@@ -1,0 +1,11 @@
+# nn_cifar10_safe
+
+CIFAR-10 training with conservative batch/epoch defaults for local dev.
+
+## Run
+
+```sh
+v run vtl/examples/nn_cifar10_safe/main.v
+```
+
+For full training see `nn_cifar10/` (high compile RAM on some hosts).

--- a/examples/nn_cifar10_tiny/README.md
+++ b/examples/nn_cifar10_tiny/README.md
@@ -1,0 +1,11 @@
+# nn_cifar10_tiny
+
+Small **real** CIFAR-10 subset (64 train / 16 test). Heavier than `tiny_synth`.
+
+## Run
+
+```sh
+v run vtl/examples/nn_cifar10_tiny/main.v
+```
+
+Downloads CIFAR-10 on first run. Not used in default CI (I/O + memory).

--- a/examples/nn_cifar10_tiny_synth/README.md
+++ b/examples/nn_cifar10_tiny_synth/README.md
@@ -1,0 +1,18 @@
+# nn_cifar10_tiny_synth
+
+Synthetic CIFAR-shaped batches (no dataset download). **Default CI smoke.**
+
+## Run
+
+```sh
+v run vtl/examples/nn_cifar10_tiny_synth/main.v
+```
+
+With CUDA Linear forward (local GPU, `-d cuda` build):
+
+```sh
+export VTL_USE_CUDA=1
+v -d cuda run vtl/examples/nn_cifar10_tiny_synth/main.v
+```
+
+See [DEV_LIGHTWEIGHT.md](../../docs/DEV_LIGHTWEIGHT.md).

--- a/examples/nn_cifar10_tiny_synth/main.v
+++ b/examples/nn_cifar10_tiny_synth/main.v
@@ -2,6 +2,7 @@ module main
 
 import vtl
 import vtl.autograd
+import vtl.nn.layers
 import vtl.nn.models
 import vtl.nn.optimizers
 
@@ -10,6 +11,9 @@ const epochs = 1
 const batches = 2
 
 fn main() {
+	if layers.cuda_linear_enabled() {
+		println('tiny_synth: CUDA forward enabled (VTL_USE_CUDA=1, -d cuda)')
+	}
 	ctx := autograd.ctx[f64]()
 	mut model := models.sequential_from_ctx[f64](ctx)
 	model.input([3, 32, 32])

--- a/examples/nn_mnist/README.md
+++ b/examples/nn_mnist/README.md
@@ -1,0 +1,11 @@
+# nn_mnist
+
+Feedforward network on MNIST (auto-download).
+
+## Run
+
+```sh
+v run vtl/examples/nn_mnist/main.v
+```
+
+Dataset helper: `datasets/mnist.v`.


### PR DESCRIPTION
## Summary

- Completes **Phase E** (all example READMEs pass `v check-md -hide-warnings`).
- Adds short READMEs for `nn_cifar10_tiny_synth`, `tiny`, `safe`, `mnist`.
- Extends `nn_cifar10_cuda` smoke to run **Conv2D + ReLU + Linear** on CUDA when opted in.
- Logs CUDA opt-in in `nn_cifar10_tiny_synth`.

## Tracking

- Opens follow-up [#101](https://github.com/vlang/vtl/issues/101) (GPU-resident Variable, Phase 2) — added to [project #8](https://github.com/orgs/vlang/projects/8) as In Progress.

## Test plan

- [x] `v check-md -hide-warnings` on new READMEs
- [x] `v run vtl/examples/nn_cifar10_tiny_synth/main.v`
- [ ] `VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v` (GPU runner)


Made with [Cursor](https://cursor.com)