### PR TITLE
feat(autograd): Phase 2 GPU activation chain (#101)

### DIFF
--- a/autograd/device_session.v
+++ b/autograd/device_session.v
@@ -9,6 +9,8 @@ import vtl.la
 pub struct DeviceSession {
 pub mut:
 	enabled bool
+	// Phase 2: opaque GPU activation chain (`DeviceGpuChain` in CUDA builds).
+	gpu_chain voidptr = unsafe { nil }
 	// Staging buffers for cuBLAS GEMM (column-major staging, row-major output)
 	gemm_x_col   []f64
 	gemm_w_col   []f64

--- a/autograd/device_session_d_cuda.v
+++ b/autograd/device_session_d_cuda.v
@@ -13,7 +13,9 @@ pub fn (mut s DeviceSession) init_device() {
 }
 
 // linear_forward_f64 runs cuBLAS GEMM with reused session buffers; returns CPU tensor.
-pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl.Tensor[f64], bias &vtl.Tensor[f64]) !&vtl.Tensor[f64] {
+// When `VTL_GPU_ACTIVATIONS=1`, reuses `input_gpu` (`&CudaTensor[f64]`) to skip input H2D.
+pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], input_gpu voidptr) !&vtl.Tensor[f64] {
 	if !s.enabled {
 		return error('device session: CUDA not enabled (set VTL_USE_CUDA=1)')
 	}
@@ -22,6 +24,10 @@ pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl
 	}
 	if !(bias.is_vector() || (bias.is_matrix() && bias.shape[0] == 1)) {
 		return error('device session linear: bias must be vector or [1, N]')
+	}
+
+	if gpu_activations_enabled() {
+		return s.linear_forward_gpu_chain(x, weights, bias, input_gpu)
 	}
 
 	dev := cuda.get_default_device()!
@@ -34,7 +40,6 @@ pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl
 	w_arr := weights.to_array()
 	wt_row := transpose_weights_row(w_arr, n, k)
 
-	// gemm_cuda expects row-major inputs; reuse output buffer across forwards.
 	mut out_row := compute.gemm_cuda(dev, x_arr, wt_row, m, n, k)!
 
 	s.gemm_out_row = resize_f64(mut s.gemm_out_row, out_row.len)

--- a/autograd/device_session_gpu_d_cuda.v
+++ b/autograd/device_session_gpu_d_cuda.v
@@ -1,0 +1,180 @@
+module autograd
+
+import vsl.cuda
+import vtl
+import vtl.storage
+
+// DeviceGpuChain holds reusable device buffers for chained Linear forwards (Phase 2).
+@[heap]
+struct DeviceGpuChain {
+mut:
+	d_a GpuDevBuf
+	d_b GpuDevBuf
+	d_c GpuDevBuf
+	// Pending CudaTensor view over d_c (ownership stays in d_c until taken).
+	pending &vtl.CudaTensor[f64] = unsafe { nil }
+}
+
+struct GpuDevBuf {
+mut:
+	ptr  voidptr
+	size int
+}
+
+fn (mut b GpuDevBuf) ensure(count int) ! {
+	sz := int(sizeof(f64)) * count
+	if b.ptr != unsafe { nil } && b.size >= sz {
+		return
+	}
+	if b.ptr != unsafe { nil } {
+		C.cudaFree(b.ptr)
+	}
+	mut ptr := unsafe { nil }
+	status := C.cudaMalloc(&ptr, sz)
+	if status != 0 {
+		return error('GpuDevBuf.ensure: cudaMalloc status ${status}')
+	}
+	b.ptr = ptr
+	b.size = sz
+}
+
+fn (b &GpuDevBuf) release() {
+	if b.ptr != unsafe { nil } {
+		C.cudaFree(b.ptr)
+	}
+}
+
+fn (mut chain DeviceGpuChain) release_all() {
+	chain.d_a.release()
+	chain.d_b.release()
+	chain.d_c.release()
+	if chain.pending != unsafe { nil } {
+		chain.pending.release()
+		chain.pending = unsafe { nil }
+	}
+}
+
+fn (mut s DeviceSession) gpu_chain_mut() &DeviceGpuChain {
+	if s.gpu_chain == unsafe { nil } {
+		s.gpu_chain = voidptr(&DeviceGpuChain{})
+	}
+	return unsafe { &DeviceGpuChain(s.gpu_chain) }
+}
+
+pub fn (mut s DeviceSession) reset_gpu_chain() {
+	if s.gpu_chain != unsafe { nil } {
+		mut chain := unsafe { &DeviceGpuChain(s.gpu_chain) }
+		chain.release_all()
+		s.gpu_chain = unsafe { nil }
+	}
+}
+
+// take_chain_activation_impl moves the pending GPU tensor to the caller (Variable).
+fn take_chain_activation_impl(mut s DeviceSession) !&vtl.CudaTensor[f64] {
+	if s.gpu_chain == unsafe { nil } {
+		return error('no gpu chain')
+	}
+	mut chain := s.gpu_chain_mut()
+	if chain.pending == unsafe { nil } {
+		return error('no pending gpu activation')
+	}
+	t := chain.pending
+	chain.pending = unsafe { nil }
+	return t
+}
+
+// linear_forward_gpu_chain runs GEMM on device; reuses input GPU activation when provided.
+fn (mut s DeviceSession) linear_forward_gpu_chain(x &vtl.Tensor[f64], weights &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], input_gpu voidptr) !&vtl.Tensor[f64] {
+	if !gpu_activations_enabled() {
+		return error('gpu chain disabled')
+	}
+	dev := cuda.get_default_device()!
+
+	m := x.shape[0]
+	k := x.shape[1]
+	n := weights.shape[0]
+
+	mut chain := s.gpu_chain_mut()
+
+	// Free previous pending view before overwriting d_c.
+	if chain.pending != unsafe { nil } {
+		chain.pending.release()
+		chain.pending = unsafe { nil }
+	}
+
+	w_arr := weights.to_array()
+	wt_row := transpose_weights_row(w_arr, n, k)
+
+	// d_a: reuse input GPU activation or upload x.
+	chain.d_a.ensure(m * k)!
+	if input_gpu != unsafe { nil } {
+		in_ct := unsafe { &vtl.CudaTensor[f64](input_gpu) }
+		if in_ct.shape != [m, k] {
+			return error('gpu chain: input activation shape mismatch')
+		}
+		// cudaMemcpy kind 4 = device-to-device (see vsl/cuda/_cfun.c.v).
+		status := C.cudaMemcpy(chain.d_a.ptr, in_ct.data.ptr, int(sizeof(f64)) * m * k, 4)
+		if status != 0 {
+			return error('gpu chain: D2D input copy status ${status}')
+		}
+	} else {
+		x_arr := x.to_array()
+		x_col := stage_col_major(mut s.gemm_x_col, x_arr, m, k)
+		status := C.cudaMemcpy(chain.d_a.ptr, x_col.data, int(sizeof(f64)) * m * k,
+			cuda.cuda_memcpy_host_to_device)
+		if status != 0 {
+			return error('gpu chain: H2D x status ${status}')
+		}
+	}
+
+	w_col := stage_col_major(mut s.gemm_w_col, wt_row, k, n)
+	chain.d_b.ensure(k * n)!
+	status_b := C.cudaMemcpy(chain.d_b.ptr, w_col.data, int(sizeof(f64)) * k * n,
+		cuda.cuda_memcpy_host_to_device)
+	if status_b != 0 {
+		return error('gpu chain: H2D w status ${status_b}')
+	}
+
+	chain.d_c.ensure(m * n)!
+	alpha := f64(1.0)
+	beta := f64(0.0)
+	status := C.cublasDgemm_v2(dev.cublas, 0, 0, m, n, k, &alpha, &f64(chain.d_a.ptr), m,
+		&f64(chain.d_b.ptr), k, &beta, &f64(chain.d_c.ptr), m)
+	if status != cuda.cublas_status_success {
+		return error('gpu chain: cublasDgemm failed: ${cuda.cublas_error(status)}')
+	}
+
+	// One D2H per layer for CPU autograd + bias; input skips H2D when chained.
+	s.gemm_out_row = resize_f64(mut s.gemm_out_row, m * n)
+	status_dl := C.cudaMemcpy(s.gemm_out_row.data, chain.d_c.ptr, int(sizeof(f64)) * m * n,
+		cuda.cuda_memcpy_device_to_host)
+	if status_dl != 0 {
+		return error('gpu chain: D2H out status ${status_dl}')
+	}
+
+	b_arr := bias.to_array()
+	for i in 0 .. s.gemm_out_row.len {
+		col_idx := i % n
+		s.gemm_out_row[i] += b_arr[col_idx]
+	}
+
+	// Hand off d_c buffer to pending activation (chain.d_c no longer owns the ptr).
+	out_ptr := chain.d_c.ptr
+	chain.d_c.ptr = unsafe { nil }
+	chain.d_c.size = 0
+	chain.pending = &vtl.CudaTensor[f64]{
+		data: &storage.CudaStorage[f64]{
+			device: dev
+			ptr:    out_ptr
+			size:   int(sizeof(f64)) * m * n
+			count:  m * n
+		}
+		memory:  .row_major
+		size:    m * n
+		shape:   [m, n]
+		strides: [n, 1]
+	}
+
+	return vtl.from_array(s.gemm_out_row, [m, n])!
+}

--- a/autograd/device_session_notd_cuda.v
+++ b/autograd/device_session_notd_cuda.v
@@ -6,6 +6,7 @@ import vtl
 pub fn (mut s DeviceSession) init_device() {}
 
 // linear_forward_f64 without CUDA build always errors so callers fall back to CPU.
-pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl.Tensor[f64], bias &vtl.Tensor[f64]) !&vtl.Tensor[f64] {
+pub fn (mut s DeviceSession) linear_forward_f64(x &vtl.Tensor[f64], weights &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], _input_gpu voidptr) !&vtl.Tensor[f64] {
 	return error('device session: build without -d cuda')
 }

--- a/autograd/device_session_test.v
+++ b/autograd/device_session_test.v
@@ -33,9 +33,9 @@ fn test_device_session_reuses_buffers_on_second_forward() ! {
 	w := vtl.from_array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [2, 3])!
 	b := vtl.from_array([0.01, 0.02], [1, 2])!
 
-	out1 := s.linear_forward_f64(x, w, b)!
+	out1 := s.linear_forward_f64(x, w, b, unsafe { nil })!
 	len_after_first := s.gemm_out_row.len
-	out2 := s.linear_forward_f64(x, w, b)!
+	out2 := s.linear_forward_f64(x, w, b, unsafe { nil })!
 	assert s.gemm_out_row.len == len_after_first, 'output buffer should be reused, not grow unbounded'
 	cpu := linear_forward_f64_cpu(x, w, b)!
 	for i in 0 .. out2.size {
@@ -43,4 +43,21 @@ fn test_device_session_reuses_buffers_on_second_forward() ! {
 		assert diff < 1e-9, 'session forward mismatch at ${i}'
 	}
 	_ = out1
+}
+
+fn test_gpu_activation_chain_skips_without_env() ! {
+	if os.getenv('VTL_TEST_CUDA') != '1' {
+		return
+	}
+	mut s := new_device_session()
+	s.init_device()
+	if !s.enabled {
+		return
+	}
+	assert !gpu_activations_enabled(), 'without VTL_GPU_ACTIVATIONS chain is off'
+	x := vtl.from_array([1.0, 2.0], [1, 2])!
+	w := vtl.from_array([0.5, 0.5, 0.1, 0.2], [2, 2])!
+	b := vtl.from_array([0.0, 0.0], [1, 2])!
+	out := s.linear_forward_f64(x, w, b, unsafe { nil })!
+	assert out.shape == [1, 2]
 }

--- a/autograd/gpu_config.v
+++ b/autograd/gpu_config.v
@@ -1,0 +1,10 @@
+module autograd
+
+import os
+
+// gpu_activations_enabled is true when Phase 2 device-resident forwards are allowed.
+// Requires `VTL_USE_CUDA=1`, `VTL_GPU_ACTIVATIONS=1`, and build flag `-d cuda`.
+@[inline]
+pub fn gpu_activations_enabled() bool {
+	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_GPU_ACTIVATIONS') == '1'
+}

--- a/autograd/variable.v
+++ b/autograd/variable.v
@@ -28,6 +28,8 @@ pub mut:
 	// otherwise it will act similar to a vtl.Tensor, only calculating
 	// forward operations
 	requires_grad bool
+	// Phase 2: optional forward-only GPU activation (`&vtl.CudaTensor[f64]` when `-d cuda`).
+	gpu_activation voidptr = unsafe { nil }
 }
 
 @[params]

--- a/autograd/variable_gpu_d_cuda.v
+++ b/autograd/variable_gpu_d_cuda.v
@@ -1,0 +1,36 @@
+module autograd
+
+import vtl
+
+pub fn (mut v Variable[f64]) clear_gpu_activation() {
+	if v.gpu_activation != unsafe { nil } {
+		unsafe { &vtl.CudaTensor[f64](v.gpu_activation) }.release()
+		v.gpu_activation = unsafe { nil }
+	}
+}
+
+pub fn (mut v Variable[f64]) set_gpu_activation(t &vtl.CudaTensor[f64]) {
+	v.clear_gpu_activation()
+	v.gpu_activation = voidptr(t)
+}
+
+pub fn (mut v Variable[f64]) take_gpu_activation_input() voidptr {
+	if v.gpu_activation == unsafe { nil } {
+		return unsafe { nil }
+	}
+	ptr := v.gpu_activation
+	v.gpu_activation = unsafe { nil }
+	return ptr
+}
+
+pub fn (mut s DeviceSession) bind_gpu_activation_to_variable(mut v Variable[f64]) {
+	if !gpu_activations_enabled() {
+		return
+	}
+	t := take_chain_activation(mut s) or { return }
+	v.set_gpu_activation(t)
+}
+
+fn take_chain_activation(mut s DeviceSession) !&vtl.CudaTensor[f64] {
+	return take_chain_activation_impl(mut s)
+}

--- a/autograd/variable_gpu_notd_cuda.v
+++ b/autograd/variable_gpu_notd_cuda.v
@@ -1,0 +1,15 @@
+module autograd
+
+// Stubs when not built with `-d cuda`.
+
+pub fn (mut v Variable[f64]) clear_gpu_activation() {}
+
+pub fn (mut v Variable[f64]) set_gpu_activation(_ voidptr) {}
+
+pub fn (mut v Variable[f64]) take_gpu_activation_input() voidptr {
+	return unsafe { nil }
+}
+
+pub fn (mut s DeviceSession) bind_gpu_activation_to_variable(mut v Variable[f64]) {
+	_ = v
+}

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -1,6 +1,7 @@
 # Device memory model (VTL autograd + CUDA)
 
-Status: **Phase 1** — opt-in CUDA compute with CPU-resident activations for autograd.
+Status: **Phase 1** complete · **Phase 2** opt-in (`VTL_GPU_ACTIVATIONS=1`) — chained
+Linear forwards keep activations on GPU between layers; CPU tensor still produced for autograd.
 
 ## Policy
 
@@ -25,6 +26,7 @@ Phase 1 removes redundant **allocations** via `DeviceSession` buffer reuse on th
 | Variable | Effect |
 |----------|--------|
 | `VTL_USE_CUDA=1` | Enable GPU forward for eligible ops |
+| `VTL_GPU_ACTIVATIONS=1` | Phase 2: chain GPU activations across Linear layers |
 | `VTL_TEST_CUDA=1` | Run GPU tests |
 
 Build: `-d cuda` required for GPU code paths.
@@ -44,7 +46,7 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 ## Roadmap (issue #91 follow-ups)
 
-- **Phase 2**: GPU-resident `Variable` for forward-only tensors (sum-type storage)
+- **Phase 2**: GPU-resident `Variable` (`gpu_activation` on `Variable`, #101) — in progress
 - **Phase 3**: CUDA backward for Linear / Conv2D
 - **Phase 4**: Optimizer state on device (fused Adam step)
 

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -21,9 +21,10 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 
 | Priority | Issue | Topic |
 |----------|-------|--------|
+| P1 | [#101](https://github.com/vlang/vtl/issues/101) | GPU-resident `Variable` (Phase 2) |
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
-| P1 | follow-up | GPU training loop Phase 2–4 ([DEVICE_MEMORY.md](DEVICE_MEMORY.md)) |
+| P1 | follow-up | GPU Phases 3–4 ([DEVICE_MEMORY.md](DEVICE_MEMORY.md)) |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | P2 | — | Vulkan in `Sequential` training (today: smoke in `nn_cifar10_vulkan`) |
 | P2 | — | `v check-md -hide-warnings` on all example READMEs |

--- a/examples/nn_cifar10_tiny_synth/README.md
+++ b/examples/nn_cifar10_tiny_synth/README.md
@@ -15,4 +15,12 @@ export VTL_USE_CUDA=1
 v -d cuda run vtl/examples/nn_cifar10_tiny_synth/main.v
 ```
 
+Phase 2 GPU activation chain (skips input H2D between Linear layers):
+
+```sh
+export VTL_USE_CUDA=1
+export VTL_GPU_ACTIVATIONS=1
+v -d cuda run vtl/examples/nn_cifar10_tiny_synth/main.v
+```
+
 See [DEV_LIGHTWEIGHT.md](../../docs/DEV_LIGHTWEIGHT.md).

--- a/nn/layers/linear.v
+++ b/nn/layers/linear.v
@@ -41,13 +41,21 @@ pub fn (layer &LinearLayer[T]) variables() []&autograd.Variable[T] {
 pub fn (layer &LinearLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
 	mut output := if sizeof(T) == 8 {
 		mut session := input.context.device_session
+		in_v := unsafe { &autograd.Variable[f64](input) }
+		in_gpu := in_v.take_gpu_activation_input()
 		linear_forward_f64(unsafe { &vtl.Tensor[f64](input.value) },
 			unsafe { &vtl.Tensor[f64](layer.weights.value) },
-			unsafe { &vtl.Tensor[f64](layer.bias.value) }, mut session)!
+			unsafe { &vtl.Tensor[f64](layer.bias.value) }, in_gpu, mut session)!
 	} else {
 		la.matmul[T](input.value, layer.weights.value.t()!)!.add[T](layer.bias.value)!
 	}
 	mut result := input.context.variable(output)
+
+	if sizeof(T) == 8 {
+		mut session := input.context.device_session
+		mut out_v := unsafe { &autograd.Variable[f64](result) }
+		session.bind_gpu_activation_to_variable(mut out_v)
+	}
 
 	if input.requires_grad || layer.weights.requires_grad || layer.bias.requires_grad {
 		gate := layers.linear_gate[T](input, layer.weights, layer.bias)

--- a/nn/layers/linear_cuda_d_cuda.v
+++ b/nn/layers/linear_cuda_d_cuda.v
@@ -14,7 +14,7 @@ pub fn linear_forward_cuda_f64(x &vtl.Tensor[f64], weights &vtl.Tensor[f64], bia
 	}
 	mut session := autograd.new_device_session()
 	session.init_device()
-	return session.linear_forward_f64(x, weights, bias)
+	return session.linear_forward_f64(x, weights, bias, unsafe { nil })
 }
 
 // relu_forward_cuda applies ReLU on GPU and returns a CPU tensor (f64 only).

--- a/nn/layers/linear_cuda_test.v
+++ b/nn/layers/linear_cuda_test.v
@@ -26,7 +26,7 @@ fn test_linear_cuda_matches_cpu_reference() ! {
 	bias_t := vars[1].value
 
 	mut no_session := &autograd.DeviceSession(unsafe { nil })
-	cpu := linear_forward_f64(input, w, bias_t, mut no_session)!
+	cpu := linear_forward_f64(input, w, bias_t, unsafe { nil }, mut no_session)!
 	gpu := linear_forward_cuda_f64(input, w, bias_t)!
 
 	assert cpu.shape == gpu.shape

--- a/nn/layers/linear_forward_f64.v
+++ b/nn/layers/linear_forward_f64.v
@@ -5,9 +5,10 @@ import vtl.autograd
 
 // linear_forward_f64 may use CUDA when enabled at runtime (`VTL_USE_CUDA=1`, `-d cuda`).
 // When session is non-nil and initialized, GEMM staging buffers are reused (issue #91).
-pub fn linear_forward_f64(input &vtl.Tensor[f64], weights &vtl.Tensor[f64], bias &vtl.Tensor[f64], mut session autograd.DeviceSession) !&vtl.Tensor[f64] {
+pub fn linear_forward_f64(input &vtl.Tensor[f64], weights &vtl.Tensor[f64], bias &vtl.Tensor[f64],
+	input_gpu voidptr, mut session autograd.DeviceSession) !&vtl.Tensor[f64] {
 	if session != unsafe { nil } {
-		if out := session.linear_forward_f64(input, weights, bias) {
+		if out := session.linear_forward_f64(input, weights, bias, input_gpu) {
 			return out
 		}
 	}


### PR DESCRIPTION
## Summary

Implements **Phase 2** of [DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md) / #101:

- `Variable.gpu_activation` — optional forward-only `CudaTensor` handle (`voidptr` + CUDA helpers)
- `VTL_GPU_ACTIVATIONS=1` — chains Linear forwards on GPU via `DeviceGpuChain`
- Reuses previous layer GPU output as GEMM input (device-to-device copy), avoiding input H2D
- Still one D2H per layer for bias + autograd CPU gates (Phases 3–4 unchanged)

## Usage

```sh
export VTL_USE_CUDA=1
export VTL_GPU_ACTIVATIONS=1
v -d cuda run vtl/examples/nn_cifar10_tiny_synth/main.v
```

## Test plan

- [x] `v test autograd/device_session_test.v` (CPU build)
- [x] `v -d cuda test autograd/device_session_test.v`
- [ ] `VTL_TEST_CUDA=1 VTL_GPU_ACTIVATIONS=1 v -d cuda test autograd/device_session_test.v` on GPU runner
- [ ] Two-layer Sequential smoke with env vars on GPU machine

Closes #101 (Phase 2 foundation; backward/optimizer on device remain follow-ups).


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced GPU activation chain support (Phase 2) for improved performance. Enable by setting `VTL_GPU_ACTIVATIONS=1` alongside `VTL_USE_CUDA=1`. Linear forward operations now reuse GPU activations between layers.

* **Documentation**
  * Updated GPU execution roadmap with Phase 2 status and configuration details.

* **Tests**
  * Added GPU activation chain validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->