### PR TITLE
feat(autograd): Phase 3 CUDA Linear backward (opt-in)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,8 +81,8 @@
 
 ### Phase F — GPU training loop (follow-up to #91)
 - [x] Phase 1: `DeviceSession` buffer reuse; CUDA forward for Linear/Conv2D
-- [ ] Phase 2: GPU-resident `Variable` (forward tensors)
-- [ ] Phase 3: CUDA backward for Linear / Conv2D
+- [x] Phase 2: GPU-resident `Variable` (forward tensors, #101/#104)
+- [x] Phase 3: CUDA backward for Linear (opt-in `VTL_CUDA_BACKWARD`; Conv2D backward TBD)
 - [ ] Phase 4: Optimizer state on device
 
 See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).

--- a/autograd/device_session_test.v
+++ b/autograd/device_session_test.v
@@ -45,6 +45,38 @@ fn test_device_session_reuses_buffers_on_second_forward() ! {
 	_ = out1
 }
 
+fn test_linear_backward_f64_cpu() ! {
+	grad := vtl.from_array([1.0, 0.5], [1, 2])!
+	input := vtl.from_array([1.0, 2.0, 3.0], [1, 3])!
+	weight := vtl.from_array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [2, 3])!
+	tensors := linear_backward_f64_cpu(grad, input, weight, true)!
+	assert tensors[0].shape == [1, 3]
+	assert tensors[1].shape == [2, 3]
+	assert tensors[2].shape == [1, 2]
+}
+
+fn test_linear_backward_cuda_matches_cpu_when_enabled() ! {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_BACKWARD') != '1' {
+		return
+	}
+	mut s := new_device_session()
+	s.init_device()
+	if !s.enabled || !cuda_backward_enabled() {
+		return
+	}
+	grad := vtl.from_array([1.0, 0.5], [1, 2])!
+	input := vtl.from_array([1.0, 2.0, 3.0], [1, 3])!
+	weight := vtl.from_array([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [2, 3])!
+	cpu := linear_backward_f64_cpu(grad, input, weight, true)!
+	gpu := linear_backward_f64(grad, input, weight, true, mut s)!
+	for ti in 0 .. 3 {
+		for i in 0 .. cpu[ti].size {
+			diff := math.abs(f64(cpu[ti].get_nth(i)) - f64(gpu[ti].get_nth(i)))
+			assert diff < 1e-6, 'backward mismatch tensor ${ti} idx ${i}'
+		}
+	}
+}
+
 fn test_gpu_activation_chain_skips_without_env() ! {
 	if os.getenv('VTL_TEST_CUDA') != '1' {
 		return

--- a/autograd/gpu_config.v
+++ b/autograd/gpu_config.v
@@ -8,3 +8,9 @@ import os
 pub fn gpu_activations_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_GPU_ACTIVATIONS') == '1'
 }
+
+// cuda_backward_enabled runs Linear gate GEMMs on GPU (Phase 3).
+@[inline]
+pub fn cuda_backward_enabled() bool {
+	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_BACKWARD') == '1'
+}

--- a/autograd/linear_backward_cuda_d_cuda.v
+++ b/autograd/linear_backward_cuda_d_cuda.v
@@ -1,0 +1,46 @@
+module autograd
+
+import vsl.cuda
+import vsl.cuda.compute
+import vtl
+import vtl.la
+
+// linear_backward_f64 runs Linear gradients; uses cuBLAS GEMM when cuda_backward_enabled.
+pub fn linear_backward_f64(grad &vtl.Tensor[f64], input &vtl.Tensor[f64], weight &vtl.Tensor[f64],
+	bias_needs_grad bool, mut session DeviceSession) ![]&vtl.Tensor[f64] {
+	if !cuda_backward_enabled() || !session.enabled {
+		return linear_backward_f64_cpu(grad, input, weight, bias_needs_grad)
+	}
+	dev := cuda.get_default_device()!
+	g := grad.to_array()
+	in_a := input.to_array()
+	w_a := weight.to_array()
+	m := grad.shape[0]
+	n := grad.shape[1]
+	k := input.shape[1]
+
+	d_in := compute.gemm_cuda(dev, g, w_a, m, k, n)!
+	grad_t := transpose_row(g, m, n)
+	d_w := compute.gemm_cuda(dev, grad_t, in_a, n, k, m)!
+	mut result := [&vtl.Tensor[f64]{
+		vtl.from_array(d_in, [m, k])!
+		vtl.from_array(d_w, [n, k])!
+		grad
+	}]
+	if bias_needs_grad {
+		ones := vtl.ones[f64]([1, m])
+		d_b := compute.gemm_cuda(dev, ones.to_array(), g, 1, n, m)!
+		result[2] = vtl.from_array(d_b, [1, n])!
+	}
+	return result
+}
+
+fn transpose_row(a []f64, rows int, cols int) []f64 {
+	mut t := []f64{len: rows * cols}
+	for r in 0 .. rows {
+		for c in 0 .. cols {
+			t[c * rows + r] = a[r * cols + c]
+		}
+	}
+	return t
+}

--- a/autograd/linear_backward_cuda_notd_cuda.v
+++ b/autograd/linear_backward_cuda_notd_cuda.v
@@ -1,0 +1,9 @@
+module autograd
+
+import vtl
+
+pub fn linear_backward_f64(grad &vtl.Tensor[f64], input &vtl.Tensor[f64], weight &vtl.Tensor[f64],
+	bias_needs_grad bool, mut session DeviceSession) ![]&vtl.Tensor[f64] {
+	_ = session
+	return linear_backward_f64_cpu(grad, input, weight, bias_needs_grad)
+}

--- a/autograd/linear_backward_f64.v
+++ b/autograd/linear_backward_f64.v
@@ -1,0 +1,18 @@
+module autograd
+
+import vtl
+import vtl.la
+
+// linear_backward_f64_cpu implements Linear gate gradients on CPU.
+pub fn linear_backward_f64_cpu(grad &vtl.Tensor[f64], input &vtl.Tensor[f64],
+	weight &vtl.Tensor[f64], bias_needs_grad bool) ![]&vtl.Tensor[f64] {
+	mut result := [grad, grad, grad]
+	result[0] = la.matmul[f64](grad, weight)!
+	result[1] = la.matmul[f64](grad.t()!, input)!
+	if bias_needs_grad {
+		batch_size := grad.shape[0]
+		ones := vtl.ones[f64]([1, batch_size])
+		result[2] = la.matmul[f64](ones, grad)!
+	}
+	return result
+}

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -1,7 +1,7 @@
 # Device memory model (VTL autograd + CUDA)
 
-Status: **Phase 1** complete · **Phase 2** opt-in (`VTL_GPU_ACTIVATIONS=1`) — chained
-Linear forwards keep activations on GPU between layers; CPU tensor still produced for autograd.
+Status: **Phase 1** complete · **Phase 2** done (`VTL_GPU_ACTIVATIONS=1`, #101/#104) ·
+**Phase 3** opt-in (`VTL_CUDA_BACKWARD=1`) — Linear backward GEMMs on GPU when enabled.
 
 ## Policy
 
@@ -10,7 +10,7 @@ Linear forwards keep activations on GPU between layers; CPU tensor still produce
 | Parameters (weights, bias) | CPU (`CpuStorage`) | Optimizers and gates use CPU matmul today |
 | Forward (Linear/Conv2D) | Compute on GPU when `VTL_USE_CUDA=1` | cuBLAS/cuDNN |
 | Forward output | **CPU tensor** | `Variable` and gates expect `CpuStorage` |
-| Backward | CPU | `LinearGate` / `conv2d_backward` use `vtl.la` on host |
+| Backward | CPU by default; GPU GEMM for Linear when `VTL_CUDA_BACKWARD=1` | Conv2D backward still on host |
 | Optimizer step | CPU | unchanged |
 
 Sync points (host ↔ device) per Linear forward today:
@@ -27,6 +27,7 @@ Phase 1 removes redundant **allocations** via `DeviceSession` buffer reuse on th
 |----------|--------|
 | `VTL_USE_CUDA=1` | Enable GPU forward for eligible ops |
 | `VTL_GPU_ACTIVATIONS=1` | Phase 2: chain GPU activations across Linear layers |
+| `VTL_CUDA_BACKWARD=1` | Phase 3: cuBLAS GEMM for Linear gate backward |
 | `VTL_TEST_CUDA=1` | Run GPU tests |
 
 Build: `-d cuda` required for GPU code paths.
@@ -46,8 +47,8 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 ## Roadmap (issue #91 follow-ups)
 
-- **Phase 2**: GPU-resident `Variable` (`gpu_activation` on `Variable`, #101) — in progress
-- **Phase 3**: CUDA backward for Linear / Conv2D
+- **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
+- **Phase 3**: CUDA backward for Linear (opt-in) — done; Conv2D backward still CPU
 - **Phase 4**: Optimizer state on device (fused Adam step)
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -17,7 +17,9 @@ or `v test vtl` can spike **RAM into the 10–20+ GB** range during compilation 
 | Variable | Default | Meaning |
 |----------|---------|---------|
 | `VTL_USE_CUDA` | off | Set to `1` to use CUDA in Linear forward (`-d cuda` build only). |
-| `VTL_TEST_CUDA` | off | Set to `1` to run GPU tests in `linear_cuda_test.v`. |
+| `VTL_GPU_ACTIVATIONS` | off | Phase 2: chain Linear activations on GPU between layers. |
+| `VTL_CUDA_BACKWARD` | off | Phase 3: cuBLAS GEMM for Linear gate backward. |
+| `VTL_TEST_CUDA` | off | Set to `1` to run GPU tests (`linear_cuda_test.v`, `device_session_test.v`). |
 | `VJOBS` | (V auto) | Cap parallel compile jobs, e.g. `VJOBS=2`. |
 
 CUDA is **opt-in** so normal CPU work never touches the GPU driver.
@@ -35,6 +37,9 @@ v run vtl/examples/nn_cifar10_tiny_synth/main.v
 
 # Single-file CUDA test (only when you want GPU)
 VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/nn/layers/linear_cuda_test.v
+VJOBS=2 v test vtl/autograd/device_session_test.v
+# GPU backward parity (optional)
+# VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VTL_CUDA_BACKWARD=1 VJOBS=1 v -d cuda test vtl/autograd/device_session_test.v
 
 # VSL CUDA ops (one file)
 VJOBS=1 v -d cuda test vsl/cuda/examples/cuda_ops_test.v

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -13,6 +13,8 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#87](https://github.com/vlang/vtl/issues/87) | Serialization + CIFAR checkpoints |
 | [#88](https://github.com/vlang/vtl/issues/88) | vs NumPy/PyTorch benchmarks + PR comments |
 | [#89](https://github.com/vlang/vtl/issues/89)–[#91](https://github.com/vlang/vtl/issues/91) | CUDA Linear/Conv2D + `DeviceSession` (Phase 1) |
+| [#101](https://github.com/vlang/vtl/issues/101)/[#104](https://github.com/vlang/vtl/pull/104) | GPU activation chain (Phase 2) |
+| Phase 3 | Linear CUDA backward (`VTL_CUDA_BACKWARD=1`) |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).
@@ -21,10 +23,10 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 
 | Priority | Issue | Topic |
 |----------|-------|--------|
-| P1 | [#101](https://github.com/vlang/vtl/issues/101) | GPU-resident `Variable` (Phase 2) |
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
-| P1 | follow-up | GPU Phases 3–4 ([DEVICE_MEMORY.md](DEVICE_MEMORY.md)) |
+| P1 | follow-up | GPU Phase 4 optimizer on device ([DEVICE_MEMORY.md](DEVICE_MEMORY.md)) |
+| P2 | — | Conv2D CUDA backward; Vulkan in `Sequential` training |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | P2 | — | Vulkan in `Sequential` training (today: smoke in `nn_cifar10_vulkan`) |
 | P2 | — | `v check-md -hide-warnings` on all example READMEs |

--- a/nn/gates/layers/linear.v
+++ b/nn/gates/layers/linear.v
@@ -21,24 +21,37 @@ pub fn linear_gate[T](input &autograd.Variable[T], weight &autograd.Variable[T],
 
 pub fn (g &LinearGate[T]) backward[T](payload &autograd.Payload[T]) ![]&vtl.Tensor[T] {
 	grad := payload.variable.grad
-	mut result := [grad, grad, grad]
 
+	if sizeof(T) == 8 {
+		mut session := g.input.context.device_session
+		tensors := autograd.linear_backward_f64(unsafe { &vtl.Tensor[f64](grad) },
+			unsafe { &vtl.Tensor[f64](g.input.value) },
+			unsafe { &vtl.Tensor[f64](g.weight.value) }, g.bias.requires_grad, mut session)!
+		mut result := [grad, grad, grad]
+		if g.input.requires_grad {
+			result[0] = unsafe { &vtl.Tensor[T](tensors[0]) }
+		}
+		if g.weight.requires_grad {
+			result[1] = unsafe { &vtl.Tensor[T](tensors[1]) }
+		}
+		if g.bias.requires_grad {
+			result[2] = unsafe { &vtl.Tensor[T](tensors[2]) }
+		}
+		return result
+	}
+
+	mut result := [grad, grad, grad]
 	if g.input.requires_grad {
 		result[0] = la.matmul[T](grad, g.weight.value)!
 	}
-
 	if g.weight.requires_grad {
 		result[1] = la.matmul[T](grad.t()!, g.input.value)!
 	}
-
 	if g.bias.requires_grad {
-		// Sum upstream gradient over the batch dimension: [1, batch_size] @ [batch_size, output_dim] = [1, output_dim]
-		// This gives the correct per-neuron bias gradient instead of a scalar.
 		batch_size := grad.shape[0]
 		ones := vtl.ones[T]([1, batch_size])
 		result[2] = la.matmul[T](ones, grad)!
 	}
-
 	return result
 }
 


### PR DESCRIPTION
## Summary
- Adds `VTL_CUDA_BACKWARD=1` opt-in path: Linear gate f64 backward uses cuBLAS GEMM on GPU when `VTL_USE_CUDA=1` and build `-d cuda`.
- CPU helper `linear_backward_f64_cpu` plus tests in `device_session_test.v`.
- Updates `DEVICE_MEMORY.md`, `ROADMAP.md`, and `ML_ROADMAP.md` (Phase 2 done, Phase 3 Linear done).

## Test plan
- [x] `v test autograd/device_session_test.v` (CPU)
- [ ] Optional GPU: `VTL_TEST_CUDA=1 VTL_CUDA_BACKWARD=1 VTL_USE_CUDA=1 v -d cuda test autograd/device_session_test.v`
- [x] `v run examples/nn_cifar10_tiny_synth/main.v`

## Follow-ups
- Conv2D CUDA backward
- Phase 4: optimizer on device (#105 follow-up issue)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPU (CUDA) acceleration for linear layer backward computation, opt-in via environment variables.

* **Tests**
  * Added tests validating linear layer backward behavior on CPU and GPU with numerical parity checks.

* **Documentation**
  * Updated guides documenting GPU feature phases, CUDA backward enablement, and updated roadmap tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->