### PR TITLE
docs: sync ML roadmap after Phase 3 (#105)

### DIFF
--- a/.github/scripts/sync-ml-project-8.sh
+++ b/.github/scripts/sync-ml-project-8.sh
@@ -12,7 +12,7 @@ IN_PROGRESS_ID="47fc9ee4"
 TODO_ID="f75ad846"
 
 # Optional: keep these open issues visible as In Progress on the board
-IN_PROGRESS_ISSUES="vlang/vtl#41 vlang/vsl#225 vlang/vtl#63"
+IN_PROGRESS_ISSUES="vlang/vtl#41 vlang/vsl#225 vlang/vtl#63 vlang/vtl#106"
 
 echo "Fetching project $PROJECT_NUMBER items..."
 items=$(gh project item-list "$PROJECT_NUMBER" --owner "$OWNER" --format json --limit 200)

--- a/autograd/gpu_config.v
+++ b/autograd/gpu_config.v
@@ -14,3 +14,9 @@ pub fn gpu_activations_enabled() bool {
 pub fn cuda_backward_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_BACKWARD') == '1'
 }
+
+// cuda_optimizer_enabled will run Adam/SGD steps on GPU (Phase 4, #106). Not implemented yet.
+@[inline]
+pub fn cuda_optimizer_enabled() bool {
+	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_OPTIMIZER') == '1'
+}

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -49,6 +49,6 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 - **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
 - **Phase 3**: CUDA backward for Linear (opt-in) — done; Conv2D backward still CPU
-- **Phase 4**: Optimizer state on device (fused Adam step)
+- **Phase 4**: Optimizer state on device (#106, `VTL_CUDA_OPTIMIZER=1` reserved, not implemented)
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -14,7 +14,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#88](https://github.com/vlang/vtl/issues/88) | vs NumPy/PyTorch benchmarks + PR comments |
 | [#89](https://github.com/vlang/vtl/issues/89)–[#91](https://github.com/vlang/vtl/issues/91) | CUDA Linear/Conv2D + `DeviceSession` (Phase 1) |
 | [#101](https://github.com/vlang/vtl/issues/101)/[#104](https://github.com/vlang/vtl/pull/104) | GPU activation chain (Phase 2) |
-| Phase 3 | Linear CUDA backward (`VTL_CUDA_BACKWARD=1`) |
+| [#105](https://github.com/vlang/vtl/pull/105) | Linear CUDA backward (`VTL_CUDA_BACKWARD=1`, Phase 3) |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).
@@ -25,7 +25,8 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
-| P1 | follow-up | GPU Phase 4 optimizer on device ([DEVICE_MEMORY.md](DEVICE_MEMORY.md)) |
+| P1 | [#106](https://github.com/vlang/vtl/issues/106) | GPU Phase 4 optimizer on device |
+| P2 | [#107](https://github.com/vlang/vtl/issues/107) | Conv2D CUDA backward |
 | P2 | — | Conv2D CUDA backward; Vulkan in `Sequential` training |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | P2 | — | Vulkan in `Sequential` training (today: smoke in `nn_cifar10_vulkan`) |


### PR DESCRIPTION
Docs-only: ML_ROADMAP, DEVICE_MEMORY Phase 4 note, gpu_config flag stub, project-8 sync includes #106.

Made with [Cursor](https://cursor.com)