### PR TITLE
feat(optimizers): Phase 4 CUDA Adam moments (#106)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@
 - [x] Phase 1: `DeviceSession` buffer reuse; CUDA forward for Linear/Conv2D
 - [x] Phase 2: GPU-resident `Variable` (forward tensors, #101/#104)
 - [x] Phase 3: CUDA backward for Linear (opt-in `VTL_CUDA_BACKWARD`; Conv2D backward TBD)
-- [ ] Phase 4: Optimizer state on device
+- [x] Phase 4: Adam GPU moments (opt-in `VTL_CUDA_OPTIMIZER`; full device state TBD)
 
 See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 

--- a/autograd/gpu_config.v
+++ b/autograd/gpu_config.v
@@ -15,7 +15,7 @@ pub fn cuda_backward_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_BACKWARD') == '1'
 }
 
-// cuda_optimizer_enabled will run Adam/SGD steps on GPU (Phase 4, #106). Not implemented yet.
+// cuda_optimizer_enabled runs Adam moment updates on GPU (Phase 4, #106); sqrt step on CPU.
 @[inline]
 pub fn cuda_optimizer_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_OPTIMIZER') == '1'

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -11,6 +11,7 @@ Status: **Phase 1** complete · **Phase 2** done (`VTL_GPU_ACTIVATIONS=1`, #101/
 | Forward (Linear/Conv2D) | Compute on GPU when `VTL_USE_CUDA=1` | cuBLAS/cuDNN |
 | Forward output | **CPU tensor** | `Variable` and gates expect `CpuStorage` |
 | Backward | CPU by default; GPU GEMM for Linear when `VTL_CUDA_BACKWARD=1` | Conv2D backward still on host |
+| Optimizer (Adam) | CPU by default; GPU moments when `VTL_CUDA_OPTIMIZER=1` | Parameter sqrt step on CPU |
 | Optimizer step | CPU | unchanged |
 
 Sync points (host ↔ device) per Linear forward today:
@@ -28,6 +29,7 @@ Phase 1 removes redundant **allocations** via `DeviceSession` buffer reuse on th
 | `VTL_USE_CUDA=1` | Enable GPU forward for eligible ops |
 | `VTL_GPU_ACTIVATIONS=1` | Phase 2: chain GPU activations across Linear layers |
 | `VTL_CUDA_BACKWARD=1` | Phase 3: cuBLAS GEMM for Linear gate backward |
+| `VTL_CUDA_OPTIMIZER=1` | Phase 4: cuBLAS moment updates for Adam |
 | `VTL_TEST_CUDA=1` | Run GPU tests |
 
 Build: `-d cuda` required for GPU code paths.
@@ -49,6 +51,6 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 - **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
 - **Phase 3**: CUDA backward for Linear (opt-in) — done; Conv2D backward still CPU
-- **Phase 4**: Optimizer state on device (#106, `VTL_CUDA_OPTIMIZER=1` reserved, not implemented)
+- **Phase 4**: Adam moment updates on GPU (#106, `VTL_CUDA_OPTIMIZER=1`); device-resident m/v + fused sqrt TBD
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -19,6 +19,7 @@ or `v test vtl` can spike **RAM into the 10–20+ GB** range during compilation 
 | `VTL_USE_CUDA` | off | Set to `1` to use CUDA in Linear forward (`-d cuda` build only). |
 | `VTL_GPU_ACTIVATIONS` | off | Phase 2: chain Linear activations on GPU between layers. |
 | `VTL_CUDA_BACKWARD` | off | Phase 3: cuBLAS GEMM for Linear gate backward. |
+| `VTL_CUDA_OPTIMIZER` | off | Phase 4: cuBLAS moment updates for Adam. |
 | `VTL_TEST_CUDA` | off | Set to `1` to run GPU tests (`linear_cuda_test.v`, `device_session_test.v`). |
 | `VJOBS` | (V auto) | Cap parallel compile jobs, e.g. `VJOBS=2`. |
 

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -25,7 +25,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
-| P1 | [#106](https://github.com/vlang/vtl/issues/106) | GPU Phase 4 optimizer on device |
+| P2 | [#106](https://github.com/vlang/vtl/issues/106) | Phase 4 follow-up: device-resident m/v + GPU sqrt |
 | P2 | [#107](https://github.com/vlang/vtl/issues/107) | Conv2D CUDA backward |
 | P2 | — | Conv2D CUDA backward; Vulkan in `Sequential` training |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |

--- a/nn/optimizers/adam.v
+++ b/nn/optimizers/adam.v
@@ -86,29 +86,40 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 	o.beta1_t *= o.beta1
 	o.beta2_t *= o.beta2
 
+	step := AdamStepParams{
+		beta1:   o.beta1
+		beta2:   o.beta2
+		lr_t:    lr_t
+		epsilon: o.epsilon
+	}
 	for i, mut v in o.params {
 		if v.requires_grad {
-			// m = beta1 * m + (1 - beta1) * grad
-			o.first_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
-				return vtl.cast[T](o.beta1 * f64(vals[0]) + (1.0 - o.beta1) * f64(vals[1]))
-			}) or { return err }
-
-			// v = beta2 * v + (1 - beta2) * grad^2
-			o.second_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
-				g := f64(vals[1])
-				return vtl.cast[T](o.beta2 * f64(vals[0]) + (1.0 - o.beta2) * g * g)
-			}) or { return err }
-
-			// theta = theta - lr_t * m / (sqrt(v) + eps)
-			m_i := o.first_moments[i]
-			v_i := o.second_moments[i]
-			v.value.napply([m_i, v_i], fn [o, lr_t] [T](vals []T, idx []int) T {
-				theta := f64(vals[0])
-				m := f64(vals[1])
-				vv := f64(vals[2])
-				return vtl.cast[T](theta - lr_t * m / (math.sqrt(vv) + o.epsilon))
-			}) or { return err }
-
+			if sizeof(T) == 8 {
+				grad := v.grad.to_array()
+				mut theta := v.value.to_array()
+				mut m := o.first_moments[i].to_array()
+				mut v_mom := o.second_moments[i].to_array()
+				adam_step_f64(grad, mut theta, mut m, mut v_mom, step)
+				v.value = vtl.from_array(theta, v.value.shape) or { return err }
+				o.first_moments[i] = vtl.from_array(m, v.value.shape) or { return err }
+				o.second_moments[i] = vtl.from_array(v_mom, v.value.shape) or { return err }
+			} else {
+				o.first_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
+					return vtl.cast[T](o.beta1 * f64(vals[0]) + (1.0 - o.beta1) * f64(vals[1]))
+				}) or { return err }
+				o.second_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
+					g := f64(vals[1])
+					return vtl.cast[T](o.beta2 * f64(vals[0]) + (1.0 - o.beta2) * g * g)
+				}) or { return err }
+				m_i := o.first_moments[i]
+				v_i := o.second_moments[i]
+				v.value.napply([m_i, v_i], fn [o, lr_t] [T](vals []T, idx []int) T {
+					theta := f64(vals[0])
+					m := f64(vals[1])
+					vv := f64(vals[2])
+					return vtl.cast[T](theta - lr_t * m / (math.sqrt(vv) + o.epsilon))
+				}) or { return err }
+			}
 			v.grad = vtl.zeros_like[T](v.value)
 		}
 	}

--- a/nn/optimizers/adam_step_cuda_d_cuda.v
+++ b/nn/optimizers/adam_step_cuda_d_cuda.v
@@ -1,0 +1,33 @@
+module optimizers
+
+import math
+import vsl.cuda
+import vsl.cuda.compute
+import vtl.autograd
+
+// adam_step_f64 runs Adam moment updates on GPU when cuda_optimizer_enabled; final
+// bias-corrected step uses CPU sqrt (no GPU sqrt kernel in VSL yet).
+pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams) {
+	if !autograd.cuda_optimizer_enabled() {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	dev := cuda.get_default_device() or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	// m = beta1*m + (1-beta1)*g
+	mut m_gpu := compute.mul_scalar_cuda(dev, m, p.beta1)!
+	m_part := compute.mul_scalar_cuda(dev, grad, 1.0 - p.beta1)!
+	m_gpu = compute.add_vec_cuda(dev, m_part, m_gpu)!
+	// v = beta2*v + (1-beta2)*g^2
+	g_sq := compute.mul_vec_cuda(dev, grad, grad)!
+	mut v_gpu := compute.mul_scalar_cuda(dev, v, p.beta2)!
+	v_part := compute.mul_scalar_cuda(dev, g_sq, 1.0 - p.beta2)!
+	v_gpu = compute.add_vec_cuda(dev, v_part, v_gpu)!
+	m = m_gpu
+	v = v_gpu
+	for i in 0 .. theta.len {
+		theta[i] -= p.lr_t * m[i] / (math.sqrt(v[i]) + p.epsilon)
+	}
+}

--- a/nn/optimizers/adam_step_cuda_notd_cuda.v
+++ b/nn/optimizers/adam_step_cuda_notd_cuda.v
@@ -1,0 +1,6 @@
+module optimizers
+
+// adam_step_f64 without CUDA build delegates to CPU.
+pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams) {
+	adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+}

--- a/nn/optimizers/adam_step_f64.v
+++ b/nn/optimizers/adam_step_f64.v
@@ -1,0 +1,23 @@
+module optimizers
+
+import math
+
+// AdamStepParams holds scalar Adam state for one flat parameter vector.
+pub struct AdamStepParams {
+pub:
+	beta1     f64
+	beta2     f64
+	lr_t      f64
+	epsilon   f64
+}
+
+// adam_step_f64_cpu performs one Adam update on flat CPU buffers.
+pub fn adam_step_f64_cpu(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams) {
+	n := grad.len
+	for i in 0 .. n {
+		g := grad[i]
+		m[i] = p.beta1 * m[i] + (1.0 - p.beta1) * g
+		v[i] = p.beta2 * v[i] + (1.0 - p.beta2) * g * g
+		theta[i] -= p.lr_t * m[i] / (math.sqrt(v[i]) + p.epsilon)
+	}
+}

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -1,5 +1,6 @@
 module optimizers
 
+import os
 import vtl
 import vtl.autograd
 
@@ -34,6 +35,61 @@ fn test_sgd_zeros_grad_after_update() ! {
 	opt.update()!
 	g := p.grad.get_nth(0)
 	assert g == 0.0, 'grad should be zeroed after update, got ${g}'
+}
+
+fn test_adam_step_f64_cpu() {
+	grad := [1.0, 2.0]
+	mut theta := [5.0, 5.0]
+	mut m := [0.0, 0.0]
+	mut v := [0.0, 0.0]
+	adam_step_f64_cpu(grad, mut theta, mut m, mut v, AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.001
+		epsilon: 1e-8
+	})
+	assert theta[0] < 5.0
+	assert m[0] > 0.0
+}
+
+fn test_adam_step_cuda_matches_cpu_when_enabled() {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
+		return
+	}
+	grad := [1.0, 2.0, 0.5]
+	mut theta_cpu := [3.0, 4.0, 5.0]
+	mut m_cpu := [0.1, 0.2, 0.3]
+	mut v_cpu := [0.01, 0.02, 0.03]
+	mut theta_gpu := theta_cpu.clone()
+	mut m_gpu := m_cpu.clone()
+	mut v_gpu := v_cpu.clone()
+	p := AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.01
+		epsilon: 1e-8
+	}
+	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
+	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p)
+	for i in 0 .. grad.len {
+		assert (theta_cpu[i] - theta_gpu[i]).abs() < 1e-6
+		assert (m_cpu[i] - m_gpu[i]).abs() < 1e-6
+		assert (v_cpu[i] - v_gpu[i]).abs() < 1e-6
+	}
+}
+
+fn test_adam_update_moves_param() ! {
+	c := ctx[f64]()
+	mut p := make_var[f64](c, 1.0)
+	mut opt := adam_optimizer[f64](learning_rate: 0.01)
+	opt.params << p
+	opt.first_moments << vtl.zeros_like[f64](p.grad)
+	opt.second_moments << vtl.zeros_like[f64](p.grad)
+	p.grad.set_nth(0, 1.0)
+	before := p.value.get_nth(0)
+	opt.update()!
+	after := p.value.get_nth(0)
+	assert after < before, 'Adam should decrease param when grad > 0'
 }
 
 fn test_adamw_update_moves_param() ! {


### PR DESCRIPTION
## Summary
- `VTL_CUDA_OPTIMIZER=1` + `-d cuda`: Adam first/second moment updates via cuBLAS (`mul_scalar`, `add_vec`, `mul_vec`).
- Parameter update (`sqrt(v)`) remains on CPU (no GPU sqrt in VSL yet).
- `adam_step_f64_cpu` extracted; tests in `optimizer_test.v`.

## Test plan
- [x] `VJOBS=2 v test nn/optimizers/optimizer_test.v`
- [ ] Optional: `VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VTL_CUDA_OPTIMIZER=1 v -d cuda test nn/optimizers/optimizer_test.v`

## Follow-ups (#106 stays open)
- Device-resident m/v buffers in `DeviceSession`
- GPU sqrt / fused Adam step
- SGD on GPU

Closes #106 partially — recommend keeping issue for follow-ups or close with comment.


Made with [Cursor](https://cursor.com)