### PR TITLE
feat(nn): Conv2D CUDA backward (#107)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,7 +82,7 @@
 ### Phase F — GPU training loop (follow-up to #91)
 - [x] Phase 1: `DeviceSession` buffer reuse; CUDA forward for Linear/Conv2D
 - [x] Phase 2: GPU-resident `Variable` (forward tensors, #101/#104)
-- [x] Phase 3: CUDA backward for Linear (opt-in `VTL_CUDA_BACKWARD`; Conv2D backward TBD)
+- [x] Phase 3: CUDA backward for Linear + Conv2D (opt-in `VTL_CUDA_BACKWARD`, #107)
 - [x] Phase 4: Adam GPU moments (opt-in `VTL_CUDA_OPTIMIZER`; full device state TBD)
 
 See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -10,7 +10,7 @@ Status: **Phase 1** complete · **Phase 2** done (`VTL_GPU_ACTIVATIONS=1`, #101/
 | Parameters (weights, bias) | CPU (`CpuStorage`) | Optimizers and gates use CPU matmul today |
 | Forward (Linear/Conv2D) | Compute on GPU when `VTL_USE_CUDA=1` | cuBLAS/cuDNN |
 | Forward output | **CPU tensor** | `Variable` and gates expect `CpuStorage` |
-| Backward | CPU by default; GPU GEMM for Linear when `VTL_CUDA_BACKWARD=1` | Conv2D backward still on host |
+| Backward | CPU by default; GPU when `VTL_CUDA_BACKWARD=1` | Linear cuBLAS; Conv2D cuDNN (eligible config) |
 | Optimizer (Adam) | CPU by default; GPU moments when `VTL_CUDA_OPTIMIZER=1` | Parameter sqrt step on CPU |
 | Optimizer step | CPU | unchanged |
 
@@ -50,7 +50,7 @@ mut model := models.sequential_from_ctx[f64](ctx)
 ## Roadmap (issue #91 follow-ups)
 
 - **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
-- **Phase 3**: CUDA backward for Linear (opt-in) — done; Conv2D backward still CPU
+- **Phase 3**: CUDA backward for Linear + Conv2D (opt-in `VTL_CUDA_BACKWARD`) — done (#107)
 - **Phase 4**: Adam moment updates on GPU (#106, `VTL_CUDA_OPTIMIZER=1`); device-resident m/v + fused sqrt TBD
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -15,6 +15,8 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#89](https://github.com/vlang/vtl/issues/89)–[#91](https://github.com/vlang/vtl/issues/91) | CUDA Linear/Conv2D + `DeviceSession` (Phase 1) |
 | [#101](https://github.com/vlang/vtl/issues/101)/[#104](https://github.com/vlang/vtl/pull/104) | GPU activation chain (Phase 2) |
 | [#105](https://github.com/vlang/vtl/pull/105) | Linear CUDA backward (`VTL_CUDA_BACKWARD=1`, Phase 3) |
+| [#107](https://github.com/vlang/vtl/issues/107) | Conv2D CUDA backward (cuDNN, same eligibility as forward) |
+| [#111](https://github.com/vlang/vtl/pull/111) | Adam GPU moments (`VTL_CUDA_OPTIMIZER=1`, Phase 4 v1) |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).
@@ -26,10 +28,9 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
 | P2 | [#106](https://github.com/vlang/vtl/issues/106) | Phase 4 follow-up: device-resident m/v + GPU sqrt |
-| P2 | [#107](https://github.com/vlang/vtl/issues/107) | Conv2D CUDA backward |
-| P2 | — | Conv2D CUDA backward; Vulkan in `Sequential` training |
+| P2 | [#110](https://github.com/vlang/vtl/issues/110) | Vulkan in `Sequential` training |
+| P2 | [#109](https://github.com/vlang/vtl/issues/109) | `nn_cifar10` CI without OOM |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
-| P2 | — | Vulkan in `Sequential` training (today: smoke in `nn_cifar10_vulkan`) |
 | P2 | — | `v check-md -hide-warnings` on all example READMEs |
 
 ## Local development

--- a/nn/internal/conv2d.v
+++ b/nn/internal/conv2d.v
@@ -88,6 +88,11 @@ pub fn conv2d_backward[T](grad_out &vtl.Tensor[T],
 	bias &vtl.Tensor[T],
 	kernel_size []int,
 	config Conv2DConfig) ![]&vtl.Tensor[T] {
+	if sizeof(T) == 8 {
+		return conv2d_backward_f64(unsafe { &vtl.Tensor[f64](grad_out) },
+			unsafe { &vtl.Tensor[f64](input) }, unsafe { &vtl.Tensor[f64](weight) },
+			unsafe { &vtl.Tensor[f64](bias) }, kernel_size, config)
+	}
 	batch := input.shape[0]
 	in_ch := input.shape[1]
 	in_h := input.shape[2]

--- a/nn/internal/conv2d_backward_cpu_f64.v
+++ b/nn/internal/conv2d_backward_cpu_f64.v
@@ -1,0 +1,92 @@
+module internal
+
+import vtl
+
+// conv2d_backward_cpu_f64 computes Conv2D gradients on CPU (reference).
+pub fn conv2d_backward_cpu_f64(grad_out &vtl.Tensor[f64], input &vtl.Tensor[f64], weight &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], kernel_size []int, config Conv2DConfig) ![]&vtl.Tensor[f64] {
+	batch := input.shape[0]
+	in_ch := input.shape[1]
+	in_h := input.shape[2]
+	in_w := input.shape[3]
+	out_ch := weight.shape[0]
+	k_h := kernel_size[0]
+	k_w := kernel_size[1]
+	pad_h := config.padding[0]
+	pad_w := config.padding[1]
+	stride_h := config.stride[0]
+	stride_w := config.stride[1]
+	dil_h := config.dilation[0]
+	dil_w := config.dilation[1]
+	groups := config.groups
+
+	out_h := grad_out.shape[2]
+	out_w := grad_out.shape[3]
+
+	mut d_input := vtl.zeros_like[f64](input)
+	for b in 0 .. batch {
+		for g in 0 .. groups {
+			g_in_ch := in_ch / groups
+			g_out_ch := out_ch / groups
+			for oc in 0 .. g_out_ch {
+				global_oc := g * g_out_ch + oc
+				for oh in 0 .. out_h {
+					for ow in 0 .. out_w {
+						goh := grad_out.get([b, global_oc, oh, ow])
+						for ic in 0 .. g_in_ch {
+							for kh in 0 .. k_h {
+								for kw in 0 .. k_w {
+									ih := oh * stride_h - pad_h + kh * dil_h
+									iw := ow * stride_w - pad_w + kw * dil_w
+									if ih >= 0 && ih < in_h && iw >= 0 && iw < in_w {
+										w_val := weight.get([global_oc, ic, kh, kw])
+										d_input.set([b, g * g_in_ch + ic, ih, iw],
+											d_input.get([b, g * g_in_ch + ic, ih, iw]) + goh * w_val)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	mut d_weight := vtl.zeros_like[f64](weight)
+	for oc in 0 .. out_ch {
+		for ic in 0 .. in_ch {
+			for kh in 0 .. k_h {
+				for kw in 0 .. k_w {
+					mut sum := 0.0
+					for b in 0 .. batch {
+						for oh in 0 .. out_h {
+							for ow in 0 .. out_w {
+								ih := oh * stride_h - pad_h + kh * dil_h
+								iw := ow * stride_w - pad_w + kw * dil_w
+								if ih >= 0 && ih < in_h && iw >= 0 && iw < in_w {
+									sum += input.get([b, ic, ih, iw]) * grad_out.get([b, oc, oh, ow])
+								}
+							}
+						}
+					}
+					d_weight.set([oc, ic, kh, kw], sum)
+				}
+			}
+		}
+	}
+
+	mut d_bias := vtl.zeros[f64]([1, out_ch])
+	for oc in 0 .. out_ch {
+		mut sum := 0.0
+		for b in 0 .. batch {
+			for oh in 0 .. out_h {
+				for ow in 0 .. out_w {
+					sum += grad_out.get([b, oc, oh, ow])
+				}
+			}
+		}
+		d_bias.set([0, oc], sum)
+	}
+	_ = bias
+	return [d_input, d_weight, d_bias]
+}

--- a/nn/internal/conv2d_backward_cuda_d_cuda.v
+++ b/nn/internal/conv2d_backward_cuda_d_cuda.v
@@ -1,0 +1,45 @@
+module internal
+
+import vsl.cuda
+import vsl.cuda.compute
+import vtl
+import vtl.autograd
+
+pub fn conv2d_backward_f64(grad_out &vtl.Tensor[f64], input &vtl.Tensor[f64], weight &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], kernel_size []int, config Conv2DConfig) ![]&vtl.Tensor[f64] {
+	if !autograd.cuda_backward_enabled() || !conv2d_cuda_eligible(kernel_size, config) {
+		return conv2d_backward_cpu_f64(grad_out, input, weight, bias, kernel_size, config)
+	}
+	batch := input.shape[0]
+	in_ch := input.shape[1]
+	in_h := input.shape[2]
+	in_w := input.shape[3]
+	out_ch := weight.shape[0]
+	k_h := kernel_size[0]
+	k_w := kernel_size[1]
+	stride_h := config.stride[0]
+	stride_w := config.stride[1]
+
+	dev := cuda.get_default_device()!
+	bwd := compute.conv2d_backward_cuda(dev, grad_out.to_array(), input.to_array(), weight.to_array(),
+		batch, in_h, in_w, in_ch, out_ch, k_h, k_w, stride_h, stride_w)!
+
+	d_input := vtl.from_array(bwd.d_input, input.shape)!
+	d_weight := vtl.from_array(bwd.d_weight, weight.shape)!
+	mut d_bias := vtl.zeros[f64]([1, out_ch])
+	out_h := grad_out.shape[2]
+	out_w := grad_out.shape[3]
+	for oc in 0 .. out_ch {
+		mut sum := 0.0
+		for b in 0 .. batch {
+			for oh in 0 .. out_h {
+				for ow in 0 .. out_w {
+					sum += grad_out.get([b, oc, oh, ow])
+				}
+			}
+		}
+		d_bias.set([0, oc], sum)
+	}
+	_ = bias
+	return [d_input, d_weight, d_bias]
+}

--- a/nn/internal/conv2d_backward_cuda_notd_cuda.v
+++ b/nn/internal/conv2d_backward_cuda_notd_cuda.v
@@ -1,0 +1,8 @@
+module internal
+
+import vtl
+
+pub fn conv2d_backward_f64(grad_out &vtl.Tensor[f64], input &vtl.Tensor[f64], weight &vtl.Tensor[f64],
+	bias &vtl.Tensor[f64], kernel_size []int, config Conv2DConfig) ![]&vtl.Tensor[f64] {
+	return conv2d_backward_cpu_f64(grad_out, input, weight, bias, kernel_size, config)
+}

--- a/nn/internal/conv2d_cuda_test.v
+++ b/nn/internal/conv2d_cuda_test.v
@@ -58,6 +58,68 @@ fn test_conv2d_forward_f64_matches_cpu_reference() ! {
 	}
 }
 
+fn test_conv2d_backward_cpu_f64_smoke() ! {
+	input := vtl.from_array([f64(1), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [
+		1,
+		1,
+		4,
+		4,
+	])!
+	weight := vtl.from_array([f64(1), 0, 0, 0, 0, 1, 0, 0, 0], [1, 1, 3, 3])!
+	bias := vtl.zeros[f64]([1, 1])
+	cfg := Conv2DConfig{
+		padding:  [1, 1]
+		stride:   [1, 1]
+		dilation: [1, 1]
+		groups:   1
+	}
+	k := [3, 3]
+	out := conv2d_forward_cpu_f64(input, weight, bias, k, cfg)!
+	grad := vtl.ones[f64](out.shape)
+	tensors := conv2d_backward_cpu_f64(grad, input, weight, bias, k, cfg)!
+	assert tensors[0].shape == input.shape
+	assert tensors[1].shape == weight.shape
+	assert tensors[2].shape == [1, 1]
+}
+
+fn test_conv2d_backward_cuda_matches_cpu() ! {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_BACKWARD') != '1' {
+		return
+	}
+	input := vtl.from_array([f64(1), 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], [
+		1,
+		1,
+		4,
+		4,
+	])!
+	weight := vtl.from_array([f64(1), 0, 0, 0, 0, 1, 0, 0, 0], [1, 1, 3, 3])!
+	bias := vtl.zeros[f64]([1, 1])
+	cfg := Conv2DConfig{
+		padding:  [1, 1]
+		stride:   [1, 1]
+		dilation: [1, 1]
+		groups:   1
+	}
+	k := [3, 3]
+	if !conv2d_cuda_eligible(k, cfg) {
+		return
+	}
+	grad := vtl.from_array([f64(0.1), 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6], [
+		1,
+		1,
+		4,
+		4,
+	])!
+	cpu := conv2d_backward_cpu_f64(grad, input, weight, bias, k, cfg)!
+	gpu := conv2d_backward_f64(grad, input, weight, bias, k, cfg)!
+	for ti in 0 .. 3 {
+		for i in 0 .. cpu[ti].size {
+			diff := math.abs(cpu[ti].get_nth(i) - gpu[ti].get_nth(i))
+			assert diff < 1e-4, 'conv2d bwd mismatch t${ti} i${i}: ${diff}'
+		}
+	}
+}
+
 fn test_conv2d_cuda_direct_optional() ! {
 	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_USE_CUDA') != '1' {
 		return


### PR DESCRIPTION
## Summary
- Opt-in `VTL_CUDA_BACKWARD=1` Conv2D backward via VSL `conv2d_backward_cuda` (cuDNN).
- Same eligibility as forward (`conv2d_cuda_eligible`).
- Depends on **vsl#297** (merge first).

## Test plan
- [x] `VJOBS=2 v test nn/internal/conv2d_cuda_test.v`
- [ ] Optional GPU: `VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VTL_CUDA_BACKWARD=1 v -d cuda test nn/internal/conv2d_cuda_test.v`

Closes #107


Made with [Cursor](https://cursor.com)