### PR TITLE
ci: scoped tests + full-ml workflow (#109)

### DIFF
--- a/.github/workflows/ci-full-ml.yml
+++ b/.github/workflows/ci-full-ml.yml
@@ -1,0 +1,49 @@
+name: CI Full ML (optional)
+
+# Heavy compile: full `v test vtl` + `examples/nn_cifar10/main.v`.
+# Default PRs use scoped `bin/test` in ci.yml to avoid OOM.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 3 * * 0'
+  pull_request:
+    types: [labeled]
+
+concurrency:
+  group: full-ml-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-ml:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'full-ml')
+    runs-on: ubuntu-22.04
+    env:
+      TERM: xterm
+      VJOBS: '1'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: vtl
+
+      - uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
+
+      - name: Install dependencies
+        run: |
+          v install vsl
+          sudo apt-get -qq update
+          sudo apt-get -qq install \
+            gfortran liblapacke-dev libopenblas-dev libgc-dev \
+            libgl1-mesa-dev opencl-headers
+
+      - name: Install VTL module
+        run: mv ./vtl ~/.vmodules
+
+      - name: Full test tree and examples
+        run: ~/.vmodules/vtl/bin/test --full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,13 @@ on:
       - '**.md'
       - '**.yml'
       - '!.github/workflows/ci.yml'
+      - '!.github/workflows/ci-full-ml.yml'
   pull_request:
     paths-ignore:
       - '**.md'
       - '**.yml'
       - '!.github/workflows/ci.yml'
+      - '!.github/workflows/ci-full-ml.yml'
 
 jobs:
   shellcheck:
@@ -170,8 +172,11 @@ jobs:
         run: mv ./vtl ~/.vmodules
 
       - name: Execute Tests
+        env:
+          VJOBS: '2'
         run: |
           if [[ "${{ matrix.backend }}" == "cblas" ]]; then
             backend_flag=--use-cblas
           fi
+          # Default: scoped tests + tiny_synth smoke (see bin/test, issue #109)
           ~/.vmodules/vtl/bin/test ${{ matrix.flags }} $backend_flag

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -54,8 +54,8 @@
 - [x] `nn_cifar10_safe` variant — safe defaults for dev/CI
 - [x] `nn_cifar10_tiny` variant — real data subset (64 train, 16 test)
 - [x] `nn_cifar10_tiny_synth` variant — synthetic data, no I/O (pipeline validation)
-- [ ] **Open Issue**: Full `nn_cifar10` crashes on CI runner (OOM at compile,
-  ~9 GB V compiler memory); runs on a local machine with enough RAM
+- [x] CI: scoped `bin/test` on PRs; full tree + `nn_cifar10/main.v` via label `full-ml` (#109)
+- [ ] Full `nn_cifar10` training remains local/high-RAM (~9 GB compile peak on small hosts)
 
 ### Phase B — DataLoader Infrastructure
 - [x] `datasets/dataloader.v` — `DataLoader[T]` with batching, shuffle, labels ([issue #86](https://github.com/vlang/vtl/issues/86) closed)
@@ -94,7 +94,7 @@ See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 | Priority | Work item |
 |----------|-----------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) Windows crash |
-| P1 | CI strategy for full `nn_cifar10` (compile memory) |
+| P2 | Label `full-ml` for optional heavy CI workflow |
 | P1 | Phases 2–4 in `DEVICE_MEMORY.md` |
 | P2 | Vulkan wired into training (not only smoke example) |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) ARM GPU |

--- a/bin/test
+++ b/bin/test
@@ -12,6 +12,7 @@
 ##         --use-cblas                       Execute tests using cblas
 ##         --use-autofree                    Execute tests using atofree
 ##         --use-gc=STRATEGY                 Execute tests using garbage collector
+##         --full                            Full v test tree and all examples (high RAM)
 ##
 
 set -e
@@ -52,20 +53,50 @@ if [[ -n "${prod}" ]]; then
     flags="${flags} -prod"
 fi
 
-echo "Executing tests with command: \"v ${flags} test .\""
-v ${flags} test ${vtl_dir_path}
+# Examples that OOM default GitHub runners at compile time (see docs/DEV_LIGHTWEIGHT.md).
+should_skip_example() {
+    case "$1" in
+        */examples/nn_cifar10/main.v) return 0 ;;
+    esac
+    return 1
+}
 
-find ${vtl_dir_path} -name '*_test' -exec rm -f {} +
+export VJOBS="${VJOBS:-2}"
+
+if [[ -n "${full}" ]]; then
+    echo "Full CI mode (high RAM): v test entire tree"
+    v ${flags} test ${vtl_dir_path}
+else
+    echo "Scoped CI mode (VJOBS=${VJOBS}): nn, autograd, datasets, core, la, storage, stats, ml"
+    v ${flags} test \
+        ${vtl_dir_path}/nn \
+        ${vtl_dir_path}/autograd \
+        ${vtl_dir_path}/datasets \
+        ${vtl_dir_path}/tests/core \
+        ${vtl_dir_path}/la \
+        ${vtl_dir_path}/storage \
+        ${vtl_dir_path}/stats \
+        ${vtl_dir_path}/ml
+fi
+
+find ${vtl_dir_path} -name '*_test' -exec rm -f {} + 2>/dev/null || true
 
 echo "Compiling Examples with flags ${flags}"
-for file in $(find "${vtl_dir_path}" -wholename '*/examples/*.v'); do
+for file in $(find "${vtl_dir_path}" -wholename '*/examples/*/main.v' | sort); do
     if [[ "${file}" == *"not_ci"* ]]; then
-        echo "Skipping ${file}"
+        echo "Skipping ${file} (not_ci)"
+        continue
+    fi
+    if should_skip_example "${file}"; then
+        echo "Skipping ${file} (heavy; use bin/test --full or label full-ml)"
         continue
     fi
     echo "Compiling ${file}"
     v ${flags} -o "${file}.bin" "${file}"
-    echo "${file}.bin created"
-    echo "Removing ${file}.bin"
     rm -f "${file}.bin"
 done
+
+if [[ -z "${full}" ]]; then
+    echo "Running nn_cifar10_tiny_synth smoke"
+    v ${flags} run ${vtl_dir_path}/examples/nn_cifar10_tiny_synth/main.v
+fi

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -46,8 +46,8 @@ VJOBS=2 v test vtl/autograd/device_session_test.v
 VJOBS=1 v -d cuda test vsl/cuda/examples/cuda_ops_test.v
 ```
 
-## CI split (suggested)
+## CI split (implemented, #109)
 
-- **PR default:** CPU scoped tests + `nn_cifar10_tiny_synth`
-- **Label `cuda`:** optional workflow with `VTL_USE_CUDA=1 -d cuda` on GPU runner
-- **Nightly:** full matrix with low parallelism
+- **PR default (`ci.yml`):** `bin/test` — scoped `v test` (nn, autograd, datasets, …) + compile examples except `nn_cifar10/main.v` + run `nn_cifar10_tiny_synth`
+- **Label `full-ml`:** workflow `ci-full-ml.yml` — `bin/test --full` (weekly schedule + manual dispatch)
+- **Local full suite:** `VJOBS=1 ~/.vmodules/vtl/bin/test --full`

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -26,10 +26,9 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | Priority | Issue | Topic |
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
-| P1 | — | Full `nn_cifar10` in CI (compile OOM on default runners) |
+| [#109](https://github.com/vlang/vtl/issues/109) | CI scoped tests + `full-ml` optional workflow |
 | P2 | [#106](https://github.com/vlang/vtl/issues/106) | Phase 4 follow-up: device-resident m/v + GPU sqrt |
 | P2 | [#110](https://github.com/vlang/vtl/issues/110) | Vulkan in `Sequential` training |
-| P2 | [#109](https://github.com/vlang/vtl/issues/109) | `nn_cifar10` CI without OOM |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | P2 | — | `v check-md -hide-warnings` on all example READMEs |
 
@@ -48,10 +47,11 @@ v run vtl/examples/nn_cifar10_tiny_synth/main.v
 # v -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 ```
 
-## CI recommendation
+## CI
 
-- **Default PR:** `nn_cifar10_tiny_synth` + scoped `v test vtl/nn`
-- **Full / CUDA / Vulkan:** labeled runners or local only
+- **Default PR:** `bin/test` (scoped modules + `nn_cifar10_tiny_synth`)
+- **`full-ml` label:** `ci-full-ml.yml` runs `bin/test --full`
+- **CUDA / Vulkan:** local or future labeled workflows
 
 ## Project board sync
 

--- a/examples/nn_cifar10/README.md
+++ b/examples/nn_cifar10/README.md
@@ -2,6 +2,12 @@
 
 A CNN example for CIFAR-10 image classification using the V Tensor Library (VTL).
 
+## CI note
+
+Default GitHub Actions **does not compile** this example (OOM on runners). PR CI uses
+`nn_cifar10_tiny_synth` instead. For full-tree validation, add the PR label **`full-ml`**
+or run locally: `VJOBS=1 ~/.vmodules/vtl/bin/test --full`.
+
 ## Overview
 
 This example demonstrates:

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -1,5 +1,6 @@
 module optimizers
 
+import math
 import os
 import vtl
 import vtl.autograd
@@ -72,9 +73,9 @@ fn test_adam_step_cuda_matches_cpu_when_enabled() {
 	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
 	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p)
 	for i in 0 .. grad.len {
-		assert (theta_cpu[i] - theta_gpu[i]).abs() < 1e-6
-		assert (m_cpu[i] - m_gpu[i]).abs() < 1e-6
-		assert (v_cpu[i] - v_gpu[i]).abs() < 1e-6
+		assert math.abs(theta_cpu[i] - theta_gpu[i]) < 1e-6
+		assert math.abs(m_cpu[i] - m_gpu[i]) < 1e-6
+		assert math.abs(v_cpu[i] - v_gpu[i]) < 1e-6
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Default CI:** `bin/test` runs scoped modules (nn, autograd, datasets, …), skips `examples/nn_cifar10/main.v`, runs `nn_cifar10_tiny_synth`.
- **Optional:** label `full-ml` or weekly `ci-full-ml.yml` runs `bin/test --full`.
- Docs: DEV_LIGHTWEIGHT, ML_ROADMAP, nn_cifar10 README.

## Test plan
- [x] Local `VJOBS=2 ./bin/test` (scoped)

Closes #109


Made with [Cursor](https://cursor.com)