### PR TITLE
feat(optimizers): persistent Adam GPU state (#106)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,7 +83,7 @@
 - [x] Phase 1: `DeviceSession` buffer reuse; CUDA forward for Linear/Conv2D
 - [x] Phase 2: GPU-resident `Variable` (forward tensors, #101/#104)
 - [x] Phase 3: CUDA backward for Linear + Conv2D (opt-in `VTL_CUDA_BACKWARD`, #107)
-- [x] Phase 4: Adam GPU moments (opt-in `VTL_CUDA_OPTIMIZER`; full device state TBD)
+- [x] Phase 4: Adam on GPU with persistent optimizer slots (`VTL_CUDA_OPTIMIZER`, #106)
 
 See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 

--- a/autograd/device_session.v
+++ b/autograd/device_session.v
@@ -15,6 +15,8 @@ pub mut:
 	gemm_x_col   []f64
 	gemm_w_col   []f64
 	gemm_out_row []f64
+	// Phase 4 (#106): opaque DeviceOptimizerState in CUDA builds.
+	optimizer_state voidptr = unsafe { nil }
 }
 
 // new_device_session creates an empty session (CUDA init is build-specific).

--- a/autograd/device_session_optimizer_d_cuda.v
+++ b/autograd/device_session_optimizer_d_cuda.v
@@ -1,0 +1,57 @@
+module autograd
+
+import vsl.cuda
+import vsl.cuda.compute
+
+// DeviceOptimizerSlot holds persistent GPU buffers for one parameter tensor (Adam #106).
+struct DeviceOptimizerSlot {
+mut:
+	d_m      compute.GpuBufF64
+	d_v      compute.GpuBufF64
+	d_g      compute.GpuBufF64
+	d_work   compute.GpuBufF64
+	d_theta  compute.GpuBufF64
+	n        int
+	gpu_sync bool // m,v,theta resident on GPU; skip H→D on next step
+}
+
+struct DeviceOptimizerState {
+mut:
+	slots []DeviceOptimizerSlot
+}
+
+fn (mut s DeviceSession) opt_state_mut() &DeviceOptimizerState {
+	if s.optimizer_state == unsafe { nil } {
+		s.optimizer_state = voidptr(&DeviceOptimizerState{})
+	}
+	return unsafe { &DeviceOptimizerState(s.optimizer_state) }
+}
+
+pub fn (mut s DeviceSession) ensure_opt_slot(slot int, n int) !&DeviceOptimizerSlot {
+	st := s.opt_state_mut()
+	for st.slots.len <= slot {
+		st.slots << DeviceOptimizerSlot{}
+	}
+	mut sl := &st.slots[slot]
+	sl.n = n
+	sl.d_m.ensure(n)!
+	sl.d_v.ensure(n)!
+	sl.d_g.ensure(n)!
+	sl.d_work.ensure(n)!
+	sl.d_theta.ensure(n)!
+	return sl
+}
+
+pub fn (mut s DeviceSession) reset_optimizer_state() {
+	if s.optimizer_state != unsafe { nil } {
+		mut st := unsafe { &DeviceOptimizerState(s.optimizer_state) }
+		for mut sl in st.slots {
+			sl.d_m.release()
+			sl.d_v.release()
+			sl.d_g.release()
+			sl.d_work.release()
+			sl.d_theta.release()
+		}
+		s.optimizer_state = unsafe { nil }
+	}
+}

--- a/autograd/gpu_config.v
+++ b/autograd/gpu_config.v
@@ -15,7 +15,7 @@ pub fn cuda_backward_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_BACKWARD') == '1'
 }
 
-// cuda_optimizer_enabled runs Adam moment updates on GPU (Phase 4, #106); sqrt step on CPU.
+// cuda_optimizer_enabled runs Adam on GPU with persistent m/v/theta in DeviceSession (#106).
 @[inline]
 pub fn cuda_optimizer_enabled() bool {
 	return os.getenv('VTL_USE_CUDA') == '1' && os.getenv('VTL_CUDA_OPTIMIZER') == '1'

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -11,7 +11,7 @@ Status: **Phase 1** complete · **Phase 2** done (`VTL_GPU_ACTIVATIONS=1`, #101/
 | Forward (Linear/Conv2D) | Compute on GPU when `VTL_USE_CUDA=1` | cuBLAS/cuDNN |
 | Forward output | **CPU tensor** | `Variable` and gates expect `CpuStorage` |
 | Backward | CPU by default; GPU when `VTL_CUDA_BACKWARD=1` | Linear cuBLAS; Conv2D cuDNN (eligible config) |
-| Optimizer (Adam) | CPU by default; GPU moments when `VTL_CUDA_OPTIMIZER=1` | Parameter sqrt step on CPU |
+| Optimizer (Adam) | CPU by default; GPU + persistent slots when `VTL_CUDA_OPTIMIZER=1` | `DeviceOptimizerState` per param |
 | Optimizer step | CPU | unchanged |
 
 Sync points (host ↔ device) per Linear forward today:
@@ -51,6 +51,6 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 - **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
 - **Phase 3**: CUDA backward for Linear + Conv2D (opt-in `VTL_CUDA_BACKWARD`) — done (#107)
-- **Phase 4**: Adam moment updates on GPU (#106, `VTL_CUDA_OPTIMIZER=1`); device-resident m/v + fused sqrt TBD
+- **Phase 4**: Adam on GPU with persistent m/v/θ in `DeviceSession` (#106, #111 follow-up)
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.

--- a/nn/optimizers/adam.v
+++ b/nn/optimizers/adam.v
@@ -95,11 +95,12 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 	for i, mut v in o.params {
 		if v.requires_grad {
 			if sizeof(T) == 8 {
+				mut session := v.context.device_session
 				grad := v.grad.to_array()
 				mut theta := v.value.to_array()
 				mut m := o.first_moments[i].to_array()
 				mut v_mom := o.second_moments[i].to_array()
-				adam_step_f64(grad, mut theta, mut m, mut v_mom, step)
+				adam_step_f64(grad, mut theta, mut m, mut v_mom, step, mut session, i)
 				v.value = vtl.from_array(theta, v.value.shape) or { return err }
 				o.first_moments[i] = vtl.from_array(m, v.value.shape) or { return err }
 				o.second_moments[i] = vtl.from_array(v_mom, v.value.shape) or { return err }

--- a/nn/optimizers/adam_step_cuda_d_cuda.v
+++ b/nn/optimizers/adam_step_cuda_d_cuda.v
@@ -1,14 +1,13 @@
 module optimizers
 
-import math
 import vsl.cuda
 import vsl.cuda.compute
 import vtl.autograd
 
-// adam_step_f64 runs Adam moment updates on GPU when cuda_optimizer_enabled; final
-// bias-corrected step uses CPU sqrt (no GPU sqrt kernel in VSL yet).
-pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams) {
-	if !autograd.cuda_optimizer_enabled() {
+// adam_step_f64 with DeviceSession persistent m/v/theta on GPU (#106).
+pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams,
+	mut session autograd.DeviceSession, slot int) {
+	if !autograd.cuda_optimizer_enabled() || !session.enabled {
 		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
 		return
 	}
@@ -16,18 +15,102 @@ pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p Ad
 		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
 		return
 	}
+	n := grad.len
+	mut sl := session.ensure_opt_slot(slot, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	if !sl.gpu_sync {
+		sl.d_m.upload(m) or {
+			adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+			return
+		}
+		sl.d_v.upload(v) or {
+			adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+			return
+		}
+		sl.d_theta.upload(theta) or {
+			adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+			return
+		}
+		sl.gpu_sync = true
+	}
+	sl.d_g.upload(grad) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
 	// m = beta1*m + (1-beta1)*g
-	mut m_gpu := compute.mul_scalar_cuda(dev, m, p.beta1)!
-	m_part := compute.mul_scalar_cuda(dev, grad, 1.0 - p.beta1)!
-	m_gpu = compute.add_vec_cuda(dev, m_part, m_gpu)!
+	compute.gpu_buf_f64_dscal(dev, mut sl.d_m, n, p.beta1) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_axpy(dev, 1.0 - p.beta1, &sl.d_g, mut sl.d_m, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
 	// v = beta2*v + (1-beta2)*g^2
-	g_sq := compute.mul_vec_cuda(dev, grad, grad)!
-	mut v_gpu := compute.mul_scalar_cuda(dev, v, p.beta2)!
-	v_part := compute.mul_scalar_cuda(dev, g_sq, 1.0 - p.beta2)!
-	v_gpu = compute.add_vec_cuda(dev, v_part, v_gpu)!
-	m = m_gpu
-	v = v_gpu
-	for i in 0 .. theta.len {
-		theta[i] -= p.lr_t * m[i] / (math.sqrt(v[i]) + p.epsilon)
+	compute.gpu_buf_f64_mul_vec(dev, &sl.d_g, &sl.d_g, mut sl.d_work, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_dscal(dev, mut sl.d_v, n, p.beta2) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_axpy(dev, 1.0 - p.beta2, &sl.d_work, mut sl.d_v, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	// theta -= lr * m / (sqrt(v) + eps) — d_work = sqrt(v)+eps, then m/d_work, axpy to theta
+	compute.gpu_buf_f64_copy(mut sl.d_work, &sl.d_v, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_sqrt_inplace(mut sl.d_work, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_add_scalar_inplace(mut sl.d_work, n, p.epsilon) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	// inv_denom on host (small sync), upload to d_work, m/denom -> d_work, theta -= lr * d_work
+	mut inv_host := []f64{len: n}
+	sl.d_work.download(mut inv_host) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	for i in 0 .. n {
+		inv_host[i] = 1.0 / inv_host[i]
+	}
+	sl.d_work.upload(inv_host) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_mul_vec(dev, &sl.d_m, &sl.d_work, mut sl.d_work, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	neg_lr := -p.lr_t
+	compute.gpu_buf_f64_dscal(dev, mut sl.d_work, n, neg_lr) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	compute.gpu_buf_f64_axpy(dev, 1.0, &sl.d_work, mut sl.d_theta, n) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	// Sync back to CPU tensors (checkpointing / serialization)
+	sl.d_m.download(mut m) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	sl.d_v.download(mut v) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	sl.d_theta.download(mut theta) or {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
 	}
 }

--- a/nn/optimizers/adam_step_cuda_notd_cuda.v
+++ b/nn/optimizers/adam_step_cuda_notd_cuda.v
@@ -1,6 +1,11 @@
 module optimizers
 
+import vtl.autograd
+
 // adam_step_f64 without CUDA build delegates to CPU.
-pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams) {
+pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams,
+	mut session autograd.DeviceSession, slot int) {
+	_ = session
+	_ = slot
 	adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
 }

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -70,12 +70,42 @@ fn test_adam_step_cuda_matches_cpu_when_enabled() {
 		lr_t:    0.01
 		epsilon: 1e-8
 	}
+	c := ctx[f64]()
+	mut session := c.device_session
 	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
-	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p)
+	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p, mut session, 0)
 	for i in 0 .. grad.len {
 		assert math.abs(theta_cpu[i] - theta_gpu[i]) < 1e-6
 		assert math.abs(m_cpu[i] - m_gpu[i]) < 1e-6
 		assert math.abs(v_cpu[i] - v_gpu[i]) < 1e-6
+	}
+}
+
+fn test_adam_step_persistent_gpu_second_step_matches_cpu() {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
+		return
+	}
+	c := ctx[f64]()
+	mut session := c.device_session
+	grad := [0.5, -0.25]
+	p := AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.01
+		epsilon: 1e-8
+	}
+	mut th_cpu := [2.0, 3.0]
+	mut m_cpu := [0.0, 0.0]
+	mut v_cpu := [0.0, 0.0]
+	mut th_gpu := th_cpu.clone()
+	mut m_gpu := m_cpu.clone()
+	mut v_gpu := v_cpu.clone()
+	for _ in 0 .. 2 {
+		adam_step_f64_cpu(grad, mut th_cpu, mut m_cpu, mut v_cpu, p)
+		adam_step_f64(grad, mut th_gpu, mut m_gpu, mut v_gpu, p, mut session, 0)
+	}
+	for i in 0 .. grad.len {
+		assert math.abs(th_cpu[i] - th_gpu[i]) < 1e-5
 	}
 }
 


### PR DESCRIPTION
## Summary
- `DeviceOptimizerState` with per-param `GpuBufF64` slots on `DeviceSession`
- `adam_step_f64` uses in-place GPU updates; `gpu_sync` skips m/v/θ re-upload
- Depends on vsl#299

## Test plan
- [x] `VJOBS=2 v test nn/optimizers/`
- [ ] GPU: `VTL_CUDA_OPTIMIZER=1 VTL_TEST_CUDA=1 v -d cuda test nn/optimizers/`

Closes #106


Made with [Cursor](https://cursor.com)