### PR TITLE
fix(nn): GPU activation chain take + example check-md

### DIFF
--- a/autograd/variable_f64_gpu_d_cuda.v
+++ b/autograd/variable_f64_gpu_d_cuda.v
@@ -1,0 +1,17 @@
+module autograd
+
+$if cuda ? {
+	// take_gpu_activation_input moves a pending GPU activation off this f64 Variable (nn Linear chain).
+	pub fn (mut v Variable[f64]) take_gpu_activation_input() voidptr {
+		if v.gpu_activation == unsafe { nil } {
+			return unsafe { nil }
+		}
+		ptr := v.gpu_activation
+		v.gpu_activation = unsafe { nil }
+		return ptr
+	}
+
+	pub fn (v Variable[f64]) has_gpu_activation() bool {
+		return v.gpu_activation != unsafe { nil }
+	}
+}

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -29,7 +29,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
-| P2 | — | `v check-md -hide-warnings` on all example READMEs |
+| P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 
 ## Local development
 

--- a/examples/nn_cifar10_vulkan/README.md
+++ b/examples/nn_cifar10_vulkan/README.md
@@ -12,7 +12,8 @@ v run vtl/examples/nn_cifar10_vulkan/main.v
 VTL_USE_VULKAN=1 v -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 ```
 
-Full f32 training (loss, backprop, Adam) is not in this example yet; only forward Linear is GPU-accelerated when opted in.
+Full f32 training (loss, backprop, Adam) is not in this example yet.
+Only forward Linear is GPU-accelerated when opted in.
 
 ## Notes
 

--- a/examples/vtl_opencl_vcl_support/README.md
+++ b/examples/vtl_opencl_vcl_support/README.md
@@ -4,7 +4,7 @@ This example shows how to use the OpenCL backend with VCL support.
 
 ## Prerequisites
 
-Read the [docs](https://vlang.github.io/vsl/vcl.html) of the V Computing Language (VCL) and the OpenCL backend.
+Read the [VCL docs](https://vlang.github.io/vsl/vcl.html) and the OpenCL backend guide.
 
 ## Running the example
 

--- a/nn/layers/linear.v
+++ b/nn/layers/linear.v
@@ -41,8 +41,7 @@ pub fn (layer &LinearLayer[T]) variables() []&autograd.Variable[T] {
 pub fn (layer &LinearLayer[T]) forward(input &autograd.Variable[T]) !&autograd.Variable[T] {
 	mut output := &vtl.Tensor[T](unsafe { nil })
 	$if sizeof(T) == 8 {
-		// GPU activation chain input is passed via session; take-from-variable needs mut input (follow-up).
-		in_gpu := unsafe { nil }
+		in_gpu := linear_take_gpu_input(voidptr(unsafe { input }))
 		out := linear_forward_f64(unsafe { &vtl.Tensor[f64](input.value) },
 			unsafe { &vtl.Tensor[f64](layer.weights.value) },
 			unsafe { &vtl.Tensor[f64](layer.bias.value) }, in_gpu, input.context.device_session)!

--- a/nn/layers/linear_gpu_chain_cuda_test.v
+++ b/nn/layers/linear_gpu_chain_cuda_test.v
@@ -1,0 +1,26 @@
+module layers
+
+import os
+import vtl
+import vtl.autograd
+import vtl.autograd_cuda
+
+$if cuda ? {
+	// Chained Linear forwards reuse device activations when VTL_GPU_ACTIVATIONS=1 (`-d cuda` only).
+	fn test_linear_gpu_activation_chain_two_layers() ! {
+		if !cuda_tests_enabled() || os.getenv('VTL_GPU_ACTIVATIONS') != '1' {
+			return
+		}
+		mut c := autograd.ctx[f64]()
+		autograd_cuda.attach_context_session(mut c)
+		l1 := linear_layer[f64](c, 3, 2)
+		l2 := linear_layer[f64](c, 2, 4)
+		inp := vtl.from_array([1.0, 2.0, 3.0], [1, 3])!
+		x := c.variable(inp)
+		h := l1.forward(x)!
+		assert h.has_gpu_activation(), 'first Linear should bind GPU activation'
+		out := l2.forward(h)!
+		assert out.value.shape == [1, 4]
+		assert !h.has_gpu_activation(), 'second Linear should take GPU activation from input'
+	}
+}

--- a/nn/layers/linear_gpu_take_d_cuda.v
+++ b/nn/layers/linear_gpu_take_d_cuda.v
@@ -1,0 +1,9 @@
+module layers
+
+import vtl.autograd
+
+// linear_take_gpu_input moves a pending GPU activation from the input Variable (f64, `-d cuda` only).
+pub fn linear_take_gpu_input(input voidptr) voidptr {
+	mut v := unsafe { &autograd.Variable[f64](input) }
+	return v.take_gpu_activation_input()
+}

--- a/nn/layers/linear_gpu_take_notd_cuda.v
+++ b/nn/layers/linear_gpu_take_notd_cuda.v
@@ -1,0 +1,6 @@
+module layers
+
+// linear_take_gpu_input is a no-op without `-d cuda` (keeps f32 nn builds free of f64 GPU take).
+pub fn linear_take_gpu_input(_input voidptr) voidptr {
+	return unsafe { nil }
+}


### PR DESCRIPTION
## Summary
- Restore Phase 2 GPU activation **take** on chained `Linear[f64]` forwards via `-d cuda` helpers (`linear_take_gpu_input`, `Variable.take_gpu_activation_input`) without polluting `Gate[f32]`.
- Add opt-in integration test `linear_gpu_chain_cuda_test.v` (`VTL_TEST_CUDA=1`, `VTL_GPU_ACTIVATIONS=1`, `-d cuda`).
- Fix `v check-md -hide-warnings examples/` (line length in `nn_cifar10_vulkan` and `vtl_opencl_vcl_support` READMEs).

## Test plan
- [x] `VJOBS=1 v test nn/f32_autograd_smoke_test.v autograd_tests/f32_gate_min_test.v nn/layers/linear_cuda_test.v`
- [x] `VJOBS=1 v check-md -hide-warnings examples/`
- [x] `v fmt -verify .`
- [ ] `VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VTL_GPU_ACTIVATIONS=1 v -d cuda test nn/layers/linear_gpu_chain_cuda_test.v` (when local CUDA build is green)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified GPU acceleration capabilities in example documentation for Vulkan and OpenCL support.
  * Updated reference links in example guides.

* **New Features**
  * Enhanced GPU activation chaining support for neural network layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->