### PR TITLE
fix(autograd_cuda): restore -d cuda compile for GPU training stack

### DIFF
--- a/autograd_cuda/device_session_optimizer_d_cuda.v
+++ b/autograd_cuda/device_session_optimizer_d_cuda.v
@@ -28,7 +28,7 @@ fn (mut s DeviceSession) opt_state_mut() &DeviceOptimizerState {
 }
 
 pub fn (mut s DeviceSession) ensure_opt_slot(slot int, n int) !&DeviceOptimizerSlot {
-	st := s.opt_state_mut()
+	mut st := s.opt_state_mut()
 	for st.slots.len <= slot {
 		st.slots << DeviceOptimizerSlot{}
 	}

--- a/autograd_cuda/linear_backward_cuda_d_cuda.v
+++ b/autograd_cuda/linear_backward_cuda_d_cuda.v
@@ -22,8 +22,9 @@ pub fn linear_backward_f64(grad &vtl.Tensor[f64], input &vtl.Tensor[f64], weight
 	d_in := compute.gemm_cuda(dev, g, w_a, m, k, n)!
 	grad_t := transpose_row(g, m, n)
 	d_w := compute.gemm_cuda(dev, grad_t, in_a, n, k, m)!
-	mut result := [&vtl.Tensor[f64]{vtl.from_array(d_in, [m, k])!, vtl.from_array(d_w, [
-		n, k])!, grad}]
+	d_in_t := vtl.from_array(d_in, [m, k])!
+	d_w_t := vtl.from_array(d_w, [n, k])!
+	mut result := [d_in_t, d_w_t, grad]
 	if bias_needs_grad {
 		ones := vtl.ones[f64]([1, m])
 		d_b := compute.gemm_cuda(dev, ones.to_array(), g, 1, n, m)!

--- a/autograd_cuda/variable_gpu_d_cuda.v
+++ b/autograd_cuda/variable_gpu_d_cuda.v
@@ -10,7 +10,9 @@ pub fn session_bind_gpu_activation(mut s DeviceSession, act_field &voidptr) {
 	if *act_field != unsafe { nil } {
 		unsafe { &vtl.CudaTensor[f64](*act_field) }.release()
 	}
-	*act_field = voidptr(t)
+	unsafe {
+		*act_field = voidptr(t)
+	}
 }
 
 fn take_chain_activation(mut s DeviceSession) !&vtl.CudaTensor[f64] {


### PR DESCRIPTION
## Summary
- Fix `mut st` in `ensure_opt_slot` (Adam optimizer state).
- Fix Linear backward CUDA result array: use `[d_in_t, d_w_t, grad]` instead of struct-literal syntax.
- Wrap `*act_field` assignment in `unsafe` for GPU activation bind.

Unblocks local `v -d cuda` builds and validates Phase 1–4 GPU paths (including `linear_gpu_chain_cuda_test`).

## Test plan
- [x] `VJOBS=1 v -d cuda test autograd_cuda/device_session_test.v`
- [x] `VJOBS=1 v -d cuda test nn/layers/linear_cuda_test.v`
- [x] `VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VTL_GPU_ACTIVATIONS=1 VJOBS=1 v -d cuda test nn/layers/linear_gpu_chain_cuda_test.v`
- [x] `VJOBS=1 v test nn/f32_autograd_smoke_test.v` (CPU, no regression)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for optimizer state handling and GPU operations.
  * Enhanced safety mechanisms in GPU activation binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->