### PR TITLE
feat(nn): f32 tiny training + Adam f32 without Gate pollution

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -97,6 +97,8 @@ for file in $(find "${vtl_dir_path}" -wholename '*/examples/*/main.v' | sort); d
 done
 
 if [[ -z "${full}" ]]; then
-    echo "Running nn_cifar10_tiny_synth smoke"
+    echo "Running nn_cifar10_tiny_synth smoke (f64)"
     v ${flags} run ${vtl_dir_path}/examples/nn_cifar10_tiny_synth/main.v
+    echo "Running nn_cifar10_f32_tiny_synth smoke (f32)"
+    v ${flags} run ${vtl_dir_path}/examples/nn_cifar10_f32_tiny_synth/main.v
 fi

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -37,6 +37,8 @@ cd ~/.vmodules
 VJOBS=2 v test vtl/nn/layers/layers_test.v
 VJOBS=2 v test vtl/nn/models/serialization_test.v
 v run vtl/examples/nn_cifar10_tiny_synth/main.v
+VJOBS=2 v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
+VJOBS=1 v test vtl/nn/f32_training_smoke_test.v vtl/nn/f32_autograd_smoke_test.v
 
 # Single-file CUDA test (only when you want GPU)
 VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/nn/layers/linear_cuda_test.v
@@ -55,6 +57,6 @@ v run vtl/examples/nn_cifar10_vulkan/main.v
 
 ## CI split (implemented, #109)
 
-- **PR default (`ci.yml`):** `bin/test` — scoped `v test` (nn, autograd, datasets, …) + compile examples except `nn_cifar10/main.v` + run `nn_cifar10_tiny_synth`
+- **PR default (`ci.yml`):** `bin/test` — scoped `v test` (nn, autograd, datasets, …) + compile examples except `nn_cifar10/main.v` + run `nn_cifar10_tiny_synth` and `nn_cifar10_f32_tiny_synth`
 - **Label `full-ml`:** workflow `ci-full-ml.yml` — `bin/test --full` (weekly schedule + manual dispatch)
 - **Local full suite:** `VJOBS=1 ~/.vmodules/vtl/bin/test --full`

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -19,6 +19,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#111](https://github.com/vlang/vtl/pull/111)/[#114](https://github.com/vlang/vtl/pull/114) | Adam on GPU + persistent `DeviceSession` slots (#106) |
 | [#110](https://github.com/vlang/vtl/issues/110) | Vulkan f32 Linear in `Sequential` forward (`VTL_USE_VULKAN=1`, `-d vulkan`) |
 | [#116](https://github.com/vlang/vtl/issues/116) | f32 autograd: `Sequential` + MSE forward/backprop compile |
+| — | f32 tiny training: `nn_cifar10_f32_tiny_synth` + `f32_training_smoke_test` |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).
@@ -40,6 +41,7 @@ v up
 cd ~/.vmodules
 v test vtl/nn vtl/datasets
 v run vtl/examples/nn_cifar10_tiny_synth/main.v
+v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
 # CUDA (opt-in)
 # VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 # Vulkan f32 Linear forward smoke

--- a/examples/nn_cifar10_f32_tiny_synth/README.md
+++ b/examples/nn_cifar10_f32_tiny_synth/README.md
@@ -1,0 +1,19 @@
+# nn_cifar10_f32_tiny_synth
+
+Synthetic mini-CIFAR batches in **f32**: `Sequential` forward, MSE, `backprop()`, and **Adam**.
+
+No dataset download.
+Complements `nn_cifar10_tiny_synth` (f64) and `nn_cifar10_vulkan` (forward-only).
+
+## Run
+
+```sh
+v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
+```
+
+## Notes
+
+- CPU only (Vulkan/CUDA examples stay in sibling folders).
+- Scoped test: `nn/f32_training_smoke_test.v`.
+
+See [DEV_LIGHTWEIGHT.md](../../docs/DEV_LIGHTWEIGHT.md).

--- a/examples/nn_cifar10_f32_tiny_synth/main.v
+++ b/examples/nn_cifar10_f32_tiny_synth/main.v
@@ -1,0 +1,45 @@
+module main
+
+import vtl
+import vtl.autograd
+import vtl.nn.models
+import vtl.nn.optimizers
+
+// f32 Sequential training smoke: forward, MSE, backprop, Adam (no dataset I/O).
+// Mirrors nn_cifar10_tiny_synth but f32 — closes the #116 compile-only gap.
+const batch_size = 2
+const epochs = 1
+const batches = 2
+
+fn main() {
+	ctx := autograd.ctx[f32]()
+	mut model := models.sequential_from_ctx[f32](ctx)
+	model.input([3, 8, 8])
+	model.flatten()
+	model.linear(4)
+	model.mse_loss()
+
+	mut opt := optimizers.adam_optimizer[f32](optimizers.AdamOptimizerConfig{
+		learning_rate: 0.01
+	})
+	opt.build_params(model.info.layers)
+
+	for epoch := 0; epoch < epochs; epoch++ {
+		for b := 0; b < batches; b++ {
+			x_tensor := vtl.ones[f32]([batch_size, 3, 8, 8])
+			y_tensor := vtl.zeros[f32]([batch_size, 4])
+
+			x := ctx.variable(x_tensor, requires_grad: true)
+			pred := model.forward(x)!
+			mut loss := model.loss(pred, y_tensor)!
+			loss_val := loss.value.get([0])
+
+			loss.backprop()!
+			opt.update()!
+
+			println('epoch ${epoch + 1}/${epochs} batch ${b + 1}/${batches} loss=${loss_val:.4f}')
+		}
+	}
+
+	println('f32 tiny synthetic training OK ✅')
+}

--- a/examples/nn_cifar10_vulkan/README.md
+++ b/examples/nn_cifar10_vulkan/README.md
@@ -12,8 +12,8 @@ v run vtl/examples/nn_cifar10_vulkan/main.v
 VTL_USE_VULKAN=1 v -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 ```
 
-Full f32 training (loss, backprop, Adam) is not in this example yet.
-Only forward Linear is GPU-accelerated when opted in.
+Full f32 training (loss, backprop, Adam): see `examples/nn_cifar10_f32_tiny_synth/`.
+This example only GPU-accelerates forward Linear when opted in.
 
 ## Notes
 

--- a/nn/f32_training_smoke_test.v
+++ b/nn/f32_training_smoke_test.v
@@ -1,0 +1,27 @@
+module nn
+
+import vtl
+import vtl.autograd
+import vtl.nn.models
+import vtl.nn.optimizers
+
+// f32 end-to-end training step: forward, MSE, backprop, Adam update.
+fn test_sequential_f32_mse_train_adam_one_step() ! {
+	ctx := autograd.ctx[f32]()
+	mut model := models.sequential_from_ctx[f32](ctx)
+	model.input([4])
+	model.linear(3)
+	model.mse_loss()
+
+	mut opt := optimizers.adam_optimizer[f32](optimizers.AdamOptimizerConfig{
+		learning_rate: 0.1
+	})
+	opt.build_params(model.info.layers)
+
+	x := ctx.variable(vtl.ones[f32]([1, 4]))
+	y := vtl.zeros[f32]([1, 3])
+	pred := model.forward(x)!
+	mut loss := model.loss(pred, y)!
+	loss.backprop()!
+	opt.update()!
+}

--- a/nn/optimizers/adam.v
+++ b/nn/optimizers/adam.v
@@ -94,7 +94,7 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 	}
 	for i, mut v in o.params {
 		if v.requires_grad {
-			if sizeof(T) == 8 {
+			$if sizeof(T) == 8 {
 				$if cuda ? {
 					if adam_use_cuda_optimizer() {
 						adam_update_f64_cuda(voidptr(v), voidptr(o.first_moments[i]),
@@ -111,7 +111,7 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 				v.value = vtl.from_array(theta, v.value.shape) or { return err }
 				o.first_moments[i] = vtl.from_array(m_arr, v.value.shape) or { return err }
 				o.second_moments[i] = vtl.from_array(v_arr, v.value.shape) or { return err }
-			} else {
+			} $else $if sizeof(T) == 4 {
 				o.first_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
 					return vtl.cast[T](o.beta1 * f64(vals[0]) + (1.0 - o.beta1) * f64(vals[1]))
 				}) or { return err }
@@ -127,6 +127,8 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 					vv := f64(vals[2])
 					return vtl.cast[T](theta - lr_t * m / (math.sqrt(vv) + o.epsilon))
 				}) or { return err }
+			} $else {
+				return error('AdamOptimizer.update: unsupported element type size ${sizeof(T)}')
 			}
 			v.grad = vtl.zeros_like[T](v.value)
 		}

--- a/nn/optimizers/adam_f64_d_cuda.v
+++ b/nn/optimizers/adam_f64_d_cuda.v
@@ -12,8 +12,7 @@ pub fn adam_update_f64_cuda(param voidptr, m_tensor voidptr, v_tensor voidptr, s
 	mut theta := v.value.to_array()
 	mut m_arr := m.to_array()
 	mut v_arr := v_mom.to_array()
-	mut session := unsafe { &autograd_cuda.DeviceSession(v.context.device_session) }
-	adam_step_f64(grad, mut theta, mut m_arr, mut v_arr, step, mut session, slot)
+	adam_step_f64(grad, mut theta, mut m_arr, mut v_arr, step, v.context.device_session, slot)
 	v.value = vtl.from_array(theta, v.value.shape)!
 	m = vtl.from_array(m_arr, v.value.shape)!
 	v_mom = vtl.from_array(v_arr, v.value.shape)!

--- a/nn/optimizers/adam_step_cuda_d_cuda.v
+++ b/nn/optimizers/adam_step_cuda_d_cuda.v
@@ -6,8 +6,13 @@ import vtl.autograd_cuda
 
 // adam_step_f64 with DeviceSession persistent m/v/theta on GPU (#106).
 pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams,
-	mut session autograd_cuda.DeviceSession, slot int) {
-	if !autograd_cuda.cuda_optimizer_enabled() || !session.enabled {
+	session voidptr, slot int) {
+	if session == unsafe { nil } {
+		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
+		return
+	}
+	mut s := unsafe { &autograd_cuda.DeviceSession(session) }
+	if !autograd_cuda.cuda_optimizer_enabled() || !s.enabled {
 		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
 		return
 	}
@@ -16,7 +21,7 @@ pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p Ad
 		return
 	}
 	n := grad.len
-	mut sl := session.ensure_opt_slot(slot, n) or {
+	mut sl := s.ensure_opt_slot(slot, n) or {
 		adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)
 		return
 	}

--- a/nn/optimizers/adam_step_cuda_notd_cuda.v
+++ b/nn/optimizers/adam_step_cuda_notd_cuda.v
@@ -1,10 +1,8 @@
 module optimizers
 
-import vtl.autograd_cuda
-
-// adam_step_f64 without CUDA build delegates to CPU.
+// adam_step_f64 without CUDA build delegates to CPU (opaque session avoids autograd_cuda import).
 pub fn adam_step_f64(grad []f64, mut theta []f64, mut m []f64, mut v []f64, p AdamStepParams,
-	mut session autograd_cuda.DeviceSession, slot int) {
+	session voidptr, slot int) {
 	_ = session
 	_ = slot
 	adam_step_f64_cpu(grad, mut theta, mut m, mut v, p)

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -73,9 +73,8 @@ fn test_adam_step_cuda_matches_cpu_when_enabled() {
 	}
 	mut c := autograd.ctx[f64]()
 	autograd_cuda.attach_context_session(mut c)
-	mut session := unsafe { &autograd_cuda.DeviceSession(c.device_session) }
 	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
-	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p, mut session, 0)
+	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
 	for i in 0 .. grad.len {
 		assert math.abs(theta_cpu[i] - theta_gpu[i]) < 1e-6
 		assert math.abs(m_cpu[i] - m_gpu[i]) < 1e-6
@@ -89,7 +88,6 @@ fn test_adam_step_persistent_gpu_second_step_matches_cpu() {
 	}
 	mut c := autograd.ctx[f64]()
 	autograd_cuda.attach_context_session(mut c)
-	mut session := unsafe { &autograd_cuda.DeviceSession(c.device_session) }
 	grad := [0.5, -0.25]
 	p := AdamStepParams{
 		beta1:   0.9
@@ -105,7 +103,7 @@ fn test_adam_step_persistent_gpu_second_step_matches_cpu() {
 	mut v_gpu := v_cpu.clone()
 	for _ in 0 .. 2 {
 		adam_step_f64_cpu(grad, mut th_cpu, mut m_cpu, mut v_cpu, p)
-		adam_step_f64(grad, mut th_gpu, mut m_gpu, mut v_gpu, p, mut session, 0)
+		adam_step_f64(grad, mut th_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
 	}
 	for i in 0 .. grad.len {
 		assert math.abs(th_cpu[i] - th_gpu[i]) < 1e-5


### PR DESCRIPTION
## Summary
- New example `nn_cifar10_f32_tiny_synth`: CIFAR-shaped f32 batches, flatten → linear → MSE, `backprop()`, Adam.
- New test `nn/f32_training_smoke_test.v` for CI coverage.
- Fix `AdamOptimizer.update` with `$if sizeof(T)` so f32 compiles (was type-checking f64 CPU path).
- Remove `autograd_cuda` import from `adam_step_cuda_notd_cuda.v` (opaque `voidptr` session) — fixes `Gate[f32]` pollution when importing optimizers.

## Test plan
- [x] `VJOBS=1 v test nn/f32_training_smoke_test.v nn/f32_autograd_smoke_test.v`
- [x] `VJOBS=1 v run examples/nn_cifar10_f32_tiny_synth/main.v`
- [x] `VJOBS=1 v test nn/optimizers/optimizer_test.v`
- [x] `v check-md -hide-warnings examples/nn_cifar10_f32_tiny_synth/README.md`


Made with [Cursor](https://cursor.com)