### PR TITLE
feat(examples): CUDA training smoke + Conv2D output_shape fix

### DIFF
--- a/autograd_cuda/training_smoke_test.v
+++ b/autograd_cuda/training_smoke_test.v
@@ -1,0 +1,42 @@
+module autograd_cuda
+
+import os
+import vtl
+import vtl.autograd
+import vtl.nn.layers
+import vtl.nn.models
+import vtl.nn.optimizers
+
+// f64 Sequential training smoke with DeviceSession (run with VTL_TEST_CUDA=1 -d cuda).
+fn test_cuda_training_smoke_two_batches() ! {
+	if os.getenv('VTL_TEST_CUDA') != '1' {
+		return
+	}
+	mut ctx := autograd.ctx[f64]()
+	attach_context_session(mut ctx)
+	mut model := models.sequential_from_ctx[f64](ctx)
+	model.input([3, 8, 8])
+	model.conv2d(3, 4, [3, 3], layers.Conv2DConfig{
+		padding: [1, 1]
+	})
+	model.relu()
+	model.flatten()
+	model.linear(3)
+	model.mse_loss()
+
+	mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
+		learning_rate: 0.001
+	})
+	opt.build_params(model.info.layers)
+
+	for b in 0 .. 2 {
+		x := ctx.variable(vtl.ones[f64]([1, 3, 8, 8]), requires_grad: true)
+		y := vtl.zeros[f64]([1, 3])
+		pred := model.forward(x)!
+		mut loss := model.loss(pred, y)!
+		loss.backprop()!
+		opt.update()!
+		_ = loss.value.get([0])
+		_ = b
+	}
+}

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -39,6 +39,8 @@ VJOBS=2 v test vtl/nn/models/serialization_test.v
 v run vtl/examples/nn_cifar10_tiny_synth/main.v
 VJOBS=2 v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
 VJOBS=1 v test vtl/nn/f32_training_smoke_test.v vtl/nn/f32_autograd_smoke_test.v
+VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/autograd_cuda/training_smoke_test.v
+VTL_USE_CUDA=1 VJOBS=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 
 # Single-file CUDA test (only when you want GPU)
 VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/nn/layers/linear_cuda_test.v

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -20,6 +20,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#110](https://github.com/vlang/vtl/issues/110) | Vulkan f32 Linear in `Sequential` forward (`VTL_USE_VULKAN=1`, `-d vulkan`) |
 | [#116](https://github.com/vlang/vtl/issues/116) | f32 autograd: `Sequential` + MSE forward/backprop compile |
 | — | f32 tiny training: `nn_cifar10_f32_tiny_synth` + `f32_training_smoke_test` |
+| — | CUDA training smoke: `nn_cifar10_cuda` + `autograd_cuda/training_smoke_test` |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).

--- a/examples/nn_cifar10_cuda/README.md
+++ b/examples/nn_cifar10_cuda/README.md
@@ -1,6 +1,7 @@
 # nn_cifar10_cuda
 
-Tiny synthetic CIFAR-shaped pipeline for **opt-in** GPU Conv2D + Linear forward.
+Synthetic mini-CIFAR f64 training: Conv2D + ReLU + Linear + MSE,
+`backprop()`, Adam, and `DeviceSession` via `autograd_cuda.attach_context_session`.
 
 ## Run (local, CUDA build)
 
@@ -9,11 +10,28 @@ export VTL_USE_CUDA=1
 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 ```
 
-Without `VTL_USE_CUDA`, the example still runs on CPU (same weights as
-`nn_cifar10_tiny_synth`).
+Phase 2 GPU activation chain between Linear layers:
+
+```bash
+export VTL_USE_CUDA=1
+export VTL_GPU_ACTIVATIONS=1
+v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
+```
+
+Without `VTL_USE_CUDA`, the example still runs on CPU (same shape as this smoke).
+
+## Test
+
+```bash
+VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/autograd_cuda/training_smoke_test.v
+```
 
 ## Notes
 
 - Not executed in default CI (CUDA link + memory).
-- For full CIFAR-10 + checkpoints see `examples/nn_cifar10/`.
-- Device session staging: `autograd/device_session_test.v` with `VTL_TEST_CUDA=1`.
+- Spatial size 8×8 (light smoke; 16×16+attach can stack-overflow on CPU backprop).
+- f32 training: `examples/nn_cifar10_f32_tiny_synth/`.
+
+See [DEVICE_MEMORY.md](../../docs/DEVICE_MEMORY.md).
+
+See [DEV_LIGHTWEIGHT.md](../../docs/DEV_LIGHTWEIGHT.md).

--- a/examples/nn_cifar10_cuda/main.v
+++ b/examples/nn_cifar10_cuda/main.v
@@ -1,35 +1,41 @@
 module main
 
+import os
 import vtl
 import vtl.autograd
+import vtl.autograd_cuda
 import vtl.nn.layers
 import vtl.nn.models
 import vtl.nn.optimizers
 
-// GPU smoke: tiny synthetic CIFAR + Conv2D + Linear on CUDA when opted in.
+// GPU smoke: synthetic mini-CIFAR, Conv2D + Linear, backprop + Adam on DeviceSession.
 //
 //   VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 //
-// CI does not run this example (requires CUDA toolchain + GPU libs).
+// Optional Phase 2 chain: export VTL_GPU_ACTIVATIONS=1
+// CI does not run this example (CUDA link + memory).
 
-const batch_size = 4
+const batch_size = 2
 const epochs = 1
 const batches = 2
 
 fn main() {
 	use_cuda := layers.cuda_linear_enabled()
-	println('nn_cifar10_cuda: VTL_USE_CUDA=${use_cuda} (-d cuda build for GPU forward)')
+	gpu_act := os.getenv('VTL_GPU_ACTIVATIONS') == '1'
+	println('nn_cifar10_cuda: VTL_USE_CUDA=${use_cuda} VTL_GPU_ACTIVATIONS=${gpu_act}')
+	println('Build with -d cuda for GPU forward paths')
 
-	ctx := autograd.ctx[f64]()
+	mut ctx := autograd.ctx[f64]()
+	autograd_cuda.attach_context_session(mut ctx)
+
 	mut model := models.sequential_from_ctx[f64](ctx)
-	model.input([3, 32, 32])
+	model.input([3, 8, 8])
 	model.conv2d(3, 8, [3, 3], layers.Conv2DConfig{
 		padding: [1, 1]
 	})
 	model.relu()
 	model.flatten()
 	model.linear(10)
-	model.softmax()
 	model.mse_loss()
 
 	mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
@@ -39,7 +45,7 @@ fn main() {
 
 	for epoch := 0; epoch < epochs; epoch++ {
 		for b := 0; b < batches; b++ {
-			x_tensor := vtl.ones[f64]([batch_size, 3, 32, 32])
+			x_tensor := vtl.ones[f64]([batch_size, 3, 8, 8])
 			y_tensor := vtl.zeros[f64]([batch_size, 10])
 
 			x := ctx.variable(x_tensor, requires_grad: true)
@@ -55,8 +61,8 @@ fn main() {
 	}
 
 	if use_cuda {
-		println('CUDA opt-in training smoke OK ✅')
+		println('CUDA DeviceSession training smoke OK ✅')
 	} else {
-		println('CPU path OK (set VTL_USE_CUDA=1 -d cuda for GPU) ✅')
+		println('CPU path OK (set VTL_USE_CUDA=1 and -d cuda for GPU) ✅')
 	}
 }

--- a/nn/layers/conv2d.v
+++ b/nn/layers/conv2d.v
@@ -32,13 +32,15 @@ pub:
 	out_channels int
 	kernel_size  []int
 	config       Conv2DConfig
+	// [C, H, W] from the previous layer when known (for output_shape / flatten).
+	input_shape []int
 pub mut:
 	weight &autograd.Variable[T] = unsafe { nil }
 	bias   &autograd.Variable[T] = unsafe { nil }
 }
 
 // conv2d_layer creates a Conv2DLayer.
-pub fn conv2d_layer[T](ctx &autograd.Context[T], in_ch int, out_ch int, kernel_size []int, config Conv2DConfig) types.Layer[T] {
+pub fn conv2d_layer[T](ctx &autograd.Context[T], in_ch int, out_ch int, kernel_size []int, config Conv2DConfig, input_shape []int) types.Layer[T] {
 	weight_shape := [out_ch, in_ch / config.groups, kernel_size[0], kernel_size[1]]
 	weight := internal.kaiming_normal[T](weight_shape)
 	bias := vtl.zeros[T]([1, out_ch])
@@ -47,14 +49,27 @@ pub fn conv2d_layer[T](ctx &autograd.Context[T], in_ch int, out_ch int, kernel_s
 		out_channels: out_ch
 		kernel_size:  kernel_size
 		config:       config
+		input_shape:  input_shape.clone()
 		weight:       ctx.variable(weight)
 		bias:         ctx.variable(bias)
 	})
 }
 
 pub fn (layer &Conv2DLayer[T]) output_shape() []int {
-	shapes := [layer.out_channels, -1, -1]
-	return shapes
+	if layer.input_shape.len >= 3 && layer.input_shape[1] > 0 && layer.input_shape[2] > 0 {
+		in_h := layer.input_shape[1]
+		in_w := layer.input_shape[2]
+		kh := layer.kernel_size[0]
+		kw := layer.kernel_size[1]
+		ph := layer.config.padding[0]
+		pw := layer.config.padding[1]
+		sh := layer.config.stride[0]
+		sw := layer.config.stride[1]
+		out_h := (in_h - kh + 2 * ph) / sh + 1
+		out_w := (in_w - kw + 2 * pw) / sw + 1
+		return [layer.out_channels, out_h, out_w]
+	}
+	return [layer.out_channels, -1, -1]
 }
 
 pub fn (layer &Conv2DLayer[T]) variables() []&autograd.Variable[T] {

--- a/nn/layers/flatten.v
+++ b/nn/layers/flatten.v
@@ -3,7 +3,6 @@ module layers
 import vtl.autograd
 import vtl.nn.gates.layers
 import vtl.nn.types
-import arrays
 
 // FlattenLayer is a layer
 pub struct FlattenLayer[T] {
@@ -17,9 +16,12 @@ pub fn flatten_layer[T](ctx &autograd.Context[T], shape []int) types.Layer[T] {
 }
 
 pub fn (layer &FlattenLayer[T]) output_shape() []int {
-	product := arrays.fold(layer.shape, 1, fn (a int, b int) int {
-		return a * b
-	})
+	mut product := 1
+	for s in layer.shape {
+		if s > 0 {
+			product *= s
+		}
+	}
 	return [product]
 }
 

--- a/nn/models/sequential_info.v
+++ b/nn/models/sequential_info.v
@@ -166,8 +166,8 @@ pub fn (mut ls SequentialInfo[T]) conv2d(in_channels int, out_channels int, kern
 	} else {
 		in_channels
 	}
-	ls.add_layer(layers.conv2d_layer[T](ls.ctx, in_ch, out_channels, kernel_size, config),
-		'Conv2DLayer', {
+	ls.add_layer(layers.conv2d_layer[T](ls.ctx, in_ch, out_channels, kernel_size, config,
+		prev_layer.output_shape()), 'Conv2DLayer', {
 		'in_channels':  in_ch
 		'out_channels': out_channels
 		'kernel_h':     kernel_size[0]

--- a/nn/optimizers/adam_f64_d_cuda.v
+++ b/nn/optimizers/adam_f64_d_cuda.v
@@ -5,7 +5,7 @@ import vtl.autograd
 import vtl.autograd_cuda
 
 pub fn adam_update_f64_cuda(param voidptr, m_tensor voidptr, v_tensor voidptr, step AdamStepParams, slot int) ! {
-	v := unsafe { &autograd.Variable[f64](param) }
+	mut v := unsafe { &autograd.Variable[f64](param) }
 	mut m := unsafe { &vtl.Tensor[f64](m_tensor) }
 	mut v_mom := unsafe { &vtl.Tensor[f64](v_tensor) }
 	grad := v.grad.to_array()


### PR DESCRIPTION
## Summary
- **`nn_cifar10_cuda`**: `attach_context_session`, Conv2D→ReLU→Flatten→Linear→MSE, Adam, 8×8 synthetic batches.
- **`autograd_cuda/training_smoke_test.v`**: opt-in f64 training smoke (`VTL_TEST_CUDA=1`, `-d cuda`).
- **Shape fixes**: Conv2D `output_shape` from previous layer spatial dims; flatten skips non-positive dims.
- **`adam_f64_d_cuda`**: `mut v` for CUDA build.

## Test plan
- [x] `VJOBS=1 v run examples/nn_cifar10_cuda/main.v` (CPU)
- [x] `VJOBS=1 v test autograd_cuda/training_smoke_test.v` (skips without env)
- [x] `VJOBS=1 v test nn/f32_training_smoke_test.v`
- [ ] `VTL_USE_CUDA=1 VTL_TEST_CUDA=1 v -d cuda test autograd_cuda/training_smoke_test.v` (local GPU + matching VSL)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA training smoke test for validating GPU-based model training workflows.

* **Improvements**
  * Updated CIFAR-10 CUDA example with optimized configuration for better performance testing.
  * Enhanced documentation with CUDA-specific build and run instructions.

* **Bug Fixes**
  * Fixed layer output shape computation to accurately track spatial dimensions through the model pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->