### PR TITLE
feat(vulkan): Conv2D forward f32 (opt-in VTL_USE_VULKAN)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -97,6 +97,7 @@ See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 | P2 | Label `full-ml` for optional heavy CI workflow |
 | P1 | Phases 2–4 in `DEVICE_MEMORY.md` |
 | — | Vulkan wired into training (`nn_cifar10_vulkan` f32 forward+backprop+Adam) |
+| P2 | Vulkan Conv2D forward f32 (no padding); GPU backward / activations / Adam TBD |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) ARM GPU |
 
 **Project board:** [vlang org project #8](https://github.com/orgs/vlang/projects/8)

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -33,6 +33,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
+| P2 | — | Vulkan Conv2D forward f32 (`VTL_USE_VULKAN`, padding=0); backward/activations/Adam GPU |
 | P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 
 ## Local development

--- a/examples/nn_cifar10_vulkan/README.md
+++ b/examples/nn_cifar10_vulkan/README.md
@@ -1,6 +1,6 @@
 # nn_cifar10_vulkan
 
-CIFAR-shaped **f32** training smoke (`[3,8,8]` → flatten → Linear → MSE). **Linear** forward/backward use Vulkan GEMM when opted in.
+CIFAR-shaped **f32** training smoke (`[3,8,8]` → Conv2D → flatten → Linear → MSE). **Linear** and **Conv2D** (no padding) use Vulkan when opted in; backward stays CPU for Conv2D.
 
 ## Run
 

--- a/examples/nn_cifar10_vulkan/main.v
+++ b/examples/nn_cifar10_vulkan/main.v
@@ -24,6 +24,8 @@ fn main() {
 	ctx := autograd.ctx[f32]()
 	mut model := models.sequential_from_ctx[f32](ctx)
 	model.input([3, 8, 8])
+	// Vulkan conv2d: no padding (VSL im2col path); same as CUDA smoke spatial size with k=3, stride=1.
+	model.conv2d(3, 8, [3, 3], layers.Conv2DConfig{padding: [0, 0], stride: [1, 1]})
 	model.flatten()
 	model.linear(10)
 	model.mse_loss()

--- a/nn/internal/conv2d.v
+++ b/nn/internal/conv2d.v
@@ -28,57 +28,10 @@ pub fn conv2d_forward[T](input &vtl.Tensor[T],
 			config)!
 		return unsafe { &vtl.Tensor[T](out) }
 	}
-	batch := input.shape[0]
-	in_ch := input.shape[1]
-	in_h := input.shape[2]
-	in_w := input.shape[3]
-	out_ch := weight.shape[0]
-	k_h := kernel_size[0]
-	k_w := kernel_size[1]
-	pad_h := config.padding[0]
-	pad_w := config.padding[1]
-	stride_h := config.stride[0]
-	stride_w := config.stride[1]
-	dil_h := config.dilation[0]
-	dil_w := config.dilation[1]
-	groups := config.groups
-
-	out_h := (in_h + 2 * pad_h - dil_h * (k_h - 1) - 1) / stride_h + 1
-	out_w := (in_w + 2 * pad_w - dil_w * (k_w - 1) - 1) / stride_w + 1
-
-	mut output := vtl.zeros[T]([batch, out_ch, out_h, out_w])
-
-	for b in 0 .. batch {
-		for g in 0 .. groups {
-			g_in_ch := in_ch / groups
-			g_out_ch := out_ch / groups
-			for oc in 0 .. g_out_ch {
-				global_oc := g * g_out_ch + oc
-				for oh in 0 .. out_h {
-					for ow in 0 .. out_w {
-						// Compute correlation at this output position
-						mut sum := f64(0)
-						for ic in 0 .. g_in_ch {
-							for kh in 0 .. k_h {
-								for kw in 0 .. k_w {
-									ih := oh * stride_h - pad_h + kh * dil_h
-									iw := ow * stride_w - pad_w + kw * dil_w
-									if ih >= 0 && ih < in_h && iw >= 0 && iw < in_w {
-										in_val := f64(input.get([b, g * g_in_ch + ic, ih, iw]))
-										w_val := f64(weight.get([global_oc, ic, kh, kw]))
-										sum += in_val * w_val
-									}
-								}
-							}
-						}
-						out_val := sum + f64(bias.get([0, global_oc]))
-						output.set([b, global_oc, oh, ow], vtl.cast[T](out_val))
-					}
-				}
-			}
-		}
-	}
-	return output
+	out_f32 := conv2d_forward_f32(unsafe { &vtl.Tensor[f32](input) },
+		unsafe { &vtl.Tensor[f32](weight) }, unsafe { &vtl.Tensor[f32](bias) }, kernel_size,
+		config)!
+	return unsafe { &vtl.Tensor[T](out_f32) }
 }
 
 // conv2d_backward computes gradients for input, weight, bias.

--- a/nn/internal/conv2d_forward_cpu_f32.v
+++ b/nn/internal/conv2d_forward_cpu_f32.v
@@ -1,0 +1,63 @@
+module internal
+
+import vtl
+
+// conv2d_forward_cpu_f32 is the reference CPU implementation (nested loops).
+pub fn conv2d_forward_cpu_f32(input &vtl.Tensor[f32],
+	weight &vtl.Tensor[f32],
+	bias &vtl.Tensor[f32],
+	kernel_size []int,
+	config Conv2DConfig) !&vtl.Tensor[f32] {
+	batch := input.shape[0]
+	in_ch := input.shape[1]
+	in_h := input.shape[2]
+	in_w := input.shape[3]
+	out_ch := weight.shape[0]
+	k_h := kernel_size[0]
+	k_w := kernel_size[1]
+	pad_h := config.padding[0]
+	pad_w := config.padding[1]
+	stride_h := config.stride[0]
+	stride_w := config.stride[1]
+	dil_h := config.dilation[0]
+	dil_w := config.dilation[1]
+	groups := config.groups
+
+	out_h := (in_h + 2 * pad_h - dil_h * (k_h - 1) - 1) / stride_h + 1
+	out_w := (in_w + 2 * pad_w - dil_w * (k_w - 1) - 1) / stride_w + 1
+
+	mut output := vtl.zeros[f32]([batch, out_ch, out_h, out_w])
+
+	for b in 0 .. batch {
+		for g in 0 .. groups {
+			g_in_ch := in_ch / groups
+			g_out_ch := out_ch / groups
+			for oc in 0 .. g_out_ch {
+				global_oc := g * g_out_ch + oc
+				for oh in 0 .. out_h {
+					for ow in 0 .. out_w {
+						mut sum := f32(0)
+						for ic in 0 .. g_in_ch {
+							for kh in 0 .. k_h {
+								for kw in 0 .. k_w {
+									ih := oh * stride_h - pad_h + kh * dil_h
+									iw := ow * stride_w - pad_w + kw * dil_w
+									if ih >= 0 && ih < in_h && iw >= 0 && iw < in_w {
+										sum += input.get([b, g * g_in_ch + ic, ih, iw]) * weight.get([
+											global_oc,
+											ic,
+											kh,
+											kw,
+										])
+									}
+								}
+							}
+						}
+						output.set([b, global_oc, oh, ow], sum + bias.get([0, global_oc]))
+					}
+				}
+			}
+		}
+	}
+	return output
+}

--- a/nn/internal/conv2d_forward_f32.v
+++ b/nn/internal/conv2d_forward_f32.v
@@ -1,0 +1,17 @@
+module internal
+
+import vtl
+
+// conv2d_forward_f32 uses Vulkan im2col+GEMM when eligible (`VTL_USE_VULKAN=1`, `-d vulkan`), else CPU.
+pub fn conv2d_forward_f32(input &vtl.Tensor[f32],
+	weight &vtl.Tensor[f32],
+	bias &vtl.Tensor[f32],
+	kernel_size []int,
+	config Conv2DConfig) !&vtl.Tensor[f32] {
+	if conv2d_vulkan_eligible(kernel_size, config) {
+		if vk_out := conv2d_forward_vulkan_f32(input, weight, bias, kernel_size, config) {
+			return vk_out
+		}
+	}
+	return conv2d_forward_cpu_f32(input, weight, bias, kernel_size, config)
+}

--- a/nn/internal/conv2d_vulkan_d_vulkan.v
+++ b/nn/internal/conv2d_vulkan_d_vulkan.v
@@ -1,0 +1,85 @@
+module internal
+
+import os
+import vtl
+import vtl.storage
+import vsl.vulkan
+import vsl.vulkan.compute
+
+// conv2d_vulkan_eligible: VSL path has no padding, groups=1, dilation=1.
+pub fn conv2d_vulkan_eligible(kernel_size []int, config Conv2DConfig) bool {
+	if os.getenv('VTL_USE_VULKAN') != '1' {
+		return false
+	}
+	if config.groups != 1 {
+		return false
+	}
+	if config.dilation != [1, 1] {
+		return false
+	}
+	return config.padding == [0, 0]
+}
+
+fn f32_flat_to_f64(arr []f32) []f64 {
+	mut out := []f64{len: arr.len}
+	for i, v in arr {
+		out[i] = f64(v)
+	}
+	return out
+}
+
+fn conv2d_vulkan_device() !&vulkan.Device {
+	mut probe := vtl.zeros[f32]([1])
+	vk := probe.vulkan(storage.VulkanParams{})!
+	defer { vk.release() }
+	return vk.data.data.device
+}
+
+// conv2d_forward_vulkan_f32 runs VSL im2col+GEMM; returns CPU tensor for autograd.
+pub fn conv2d_forward_vulkan_f32(input &vtl.Tensor[f32],
+	weight &vtl.Tensor[f32],
+	bias &vtl.Tensor[f32],
+	kernel_size []int,
+	config Conv2DConfig) !&vtl.Tensor[f32] {
+	if !conv2d_vulkan_eligible(kernel_size, config) {
+		return error('conv2d_forward_vulkan_f32: config not supported by Vulkan path')
+	}
+
+	batch := input.shape[0]
+	in_ch := input.shape[1]
+	in_h := input.shape[2]
+	in_w := input.shape[3]
+	out_ch := weight.shape[0]
+	k_h := kernel_size[0]
+	k_w := kernel_size[1]
+	stride_h := config.stride[0]
+	stride_w := config.stride[1]
+
+	dev := conv2d_vulkan_device()!
+	in_flat := f32_flat_to_f64(input.to_array())
+	w_flat := f32_flat_to_f64(weight.to_array())
+
+	out_flat := compute.conv2d_vulkan(dev, in_flat, w_flat, batch, in_h, in_w, in_ch, out_ch, k_h,
+		k_w, stride_h, stride_w)!
+
+	out_h := (in_h - k_h) / stride_h + 1
+	out_w := (in_w - k_w) / stride_w + 1
+
+	mut out_f32 := []f32{len: out_flat.len}
+	for i, v in out_flat {
+		out_f32[i] = f32(v)
+	}
+	for b in 0 .. batch {
+		for oc in 0 .. out_ch {
+			bv := bias.get([0, oc])
+			for oh in 0 .. out_h {
+				for ow in 0 .. out_w {
+					idx := ((b * out_ch + oc) * out_h + oh) * out_w + ow
+					out_f32[idx] += bv
+				}
+			}
+		}
+	}
+
+	return vtl.from_array(out_f32, [batch, out_ch, out_h, out_w])!
+}

--- a/nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v
+++ b/nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v
@@ -1,0 +1,34 @@
+module internal
+
+import math
+import os
+import vtl
+
+fn test_conv2d_forward_vulkan_f32_matches_cpu() ! {
+	if os.getenv('VTL_USE_VULKAN') != '1' {
+		return
+	}
+	cfg := Conv2DConfig{
+		padding: [0, 0]
+		stride:  [1, 1]
+	}
+	k := [3, 3]
+	if !conv2d_vulkan_eligible(k, cfg) {
+		return
+	}
+	input := vtl.ones[f32]([1, 2, 8, 8])
+	weight := vtl.ones[f32]([4, 2, 3, 3])
+	bias := vtl.zeros[f32]([1, 4])
+	cpu := conv2d_forward_cpu_f32(input, weight, bias, k, cfg)!
+	gpu := conv2d_forward_vulkan_f32(input, weight, bias, k, cfg)!
+	for i in 0 .. cpu.shape[0] {
+		for j in 0 .. cpu.shape[1] {
+			for h in 0 .. cpu.shape[2] {
+				for w in 0 .. cpu.shape[3] {
+					diff := math.abs(cpu.get([i, j, h, w]) - gpu.get([i, j, h, w]))
+					assert diff < 0.05, 'conv2d vulkan mismatch at [${i},${j},${h},${w}]: ${diff}'
+				}
+			}
+		}
+	}
+}

--- a/nn/internal/conv2d_vulkan_notd_vulkan.v
+++ b/nn/internal/conv2d_vulkan_notd_vulkan.v
@@ -1,0 +1,17 @@
+module internal
+
+import vtl
+
+// conv2d_vulkan_eligible is false without `-d vulkan`.
+pub fn conv2d_vulkan_eligible(kernel_size []int, config Conv2DConfig) bool {
+	return false
+}
+
+// conv2d_forward_vulkan_f32 stub when not built with `-d vulkan`.
+pub fn conv2d_forward_vulkan_f32(input &vtl.Tensor[f32],
+	weight &vtl.Tensor[f32],
+	bias &vtl.Tensor[f32],
+	kernel_size []int,
+	config Conv2DConfig) !&vtl.Tensor[f32] {
+	return error(@FN + ': compile with -d vulkan for Vulkan conv2d')
+}


### PR DESCRIPTION
## Summary
- Add `conv2d_forward_f32` dispatcher with Vulkan path (`conv2d_vulkan_d_vulkan.v`, `_notd_vulkan` stubs).
- Eligibility: `VTL_USE_VULKAN=1`, `padding=[0,0]`, `groups=1`, `dilation=[1,1]`.
- Extend `nn_cifar10_vulkan` with Conv2D in the training loop.
- Add `conv2d_vulkan_forward_f32_d_vulkan_test.v` (GPU vs CPU parity).

**Depends on:** https://github.com/vlang/vsl/pull/302 (Vulkan GEMM dispatch + im2col layout).

## Test plan
- [x] `v test nn/conv2d_autograd_smoke_test.v`
- [x] `v run examples/nn_cifar10_vulkan/main.v` (CPU)
- [x] `VTL_USE_VULKAN=1 v -prod -d vulkan test nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v`
- [x] `VTL_USE_VULKAN=1 v -prod -d vulkan run examples/nn_cifar10_vulkan/main.v`

## Still open (Vulkan)
- Conv2D backward on GPU
- Activations on GPU in Sequential
- Adam on GPU
- `-prod` workaround for debug Vulkan instance


Made with [Cursor](https://cursor.com)