### PR TITLE
feat(vulkan): f32 ReLU/Sigmoid via VSL compute unary ops

### DIFF
--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -58,6 +58,7 @@ VJOBS=2 v test vtl/nn/layers/linear_vulkan_integration_test.v
 v run vtl/examples/nn_cifar10_vulkan/main.v
 # VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 # VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v vtl/nn/internal/conv2d_vulkan_backward_f32_d_vulkan_test.v
+# VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v
 ```
 
 ## CI split (implemented, #109)

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -33,7 +33,8 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
-| P2 | — | Vulkan: Conv2D backward d_weight GPU (padding=0); forward same-pad; activations/Adam GPU TBD |
+| — | Vulkan f32 activations via `relu_vulkan_f32` / `sigmoid_vulkan_f32` (compute path) |
+| P2 | — | Vulkan: Conv2D backward d_weight with same-padding; Adam f32 GPU |
 | P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 
 ## Local development

--- a/examples/nn_cifar10_vulkan/README.md
+++ b/examples/nn_cifar10_vulkan/README.md
@@ -1,6 +1,6 @@
 # nn_cifar10_vulkan
 
-CIFAR-shaped **f32** training smoke (`[3,8,8]` → Conv2D → flatten → Linear → MSE). **Linear** and **Conv2D** (no padding) use Vulkan when opted in; backward stays CPU for Conv2D.
+CIFAR-shaped **f32** training smoke (`[3,8,8]` → Conv2D → ReLU → flatten → Linear → MSE). **Linear**, **Conv2D** (same-padding), and **ReLU** use Vulkan compute when opted in; Conv2D `d_input` stays CPU.
 
 ## Run
 

--- a/examples/nn_cifar10_vulkan/main.v
+++ b/examples/nn_cifar10_vulkan/main.v
@@ -25,6 +25,7 @@ fn main() {
 	mut model := models.sequential_from_ctx[f32](ctx)
 	model.input([3, 8, 8])
 	model.conv2d(3, 8, [3, 3], layers.Conv2DConfig{padding: [1, 1], stride: [1, 1]})
+	model.relu()
 	model.flatten()
 	model.linear(10)
 	model.mse_loss()

--- a/nn/layers/activation_relu_forward_f32_try_d_vulkan.v
+++ b/nn/layers/activation_relu_forward_f32_try_d_vulkan.v
@@ -2,14 +2,12 @@ module layers
 
 import vtl
 
-// GPU ReLU/Sigmoid forward disabled until V 0.5.1 C codegen for VulkanTensor ops is stable.
-// Linear/Conv2D Vulkan paths remain enabled. CPU activations via internal.* in relu_forward_f32.
 pub fn relu_forward_f32_try(x &vtl.Tensor[f32]) ?&vtl.Tensor[f32] {
-	_ = x
-	return none
+	out := relu_forward_vulkan_f32(x) or { return none }
+	return out
 }
 
 pub fn sigmoid_forward_f32_try(x &vtl.Tensor[f32]) ?&vtl.Tensor[f32] {
-	_ = x
-	return none
+	out := sigmoid_forward_vulkan_f32(x) or { return none }
+	return out
 }

--- a/nn/layers/activation_vulkan_d_vulkan.v
+++ b/nn/layers/activation_vulkan_d_vulkan.v
@@ -1,0 +1,27 @@
+module layers
+
+import vtl
+import vtl.storage
+import vsl.vulkan
+import vsl.vulkan.compute
+
+fn activation_vulkan_device() !&vulkan.Device {
+	mut probe := vtl.zeros[f32]([1])
+	vk := probe.vulkan(storage.VulkanParams{})!
+	defer { vk.release() }
+	return vk.data.data.device
+}
+
+// relu_forward_vulkan_f32 uses VSL unary GPU ops (host I/O) — avoids VulkanTensor method codegen issues.
+pub fn relu_forward_vulkan_f32(x &vtl.Tensor[f32]) !&vtl.Tensor[f32] {
+	dev := activation_vulkan_device()!
+	out_arr := compute.relu_vulkan_f32(dev, x.to_array())!
+	return vtl.from_array(out_arr, x.shape)!
+}
+
+// sigmoid_forward_vulkan_f32 uses VSL unary GPU ops (host I/O).
+pub fn sigmoid_forward_vulkan_f32(x &vtl.Tensor[f32]) !&vtl.Tensor[f32] {
+	dev := activation_vulkan_device()!
+	out_arr := compute.sigmoid_vulkan_f32(dev, x.to_array())!
+	return vtl.from_array(out_arr, x.shape)!
+}

--- a/nn/layers/activation_vulkan_notd_vulkan.v
+++ b/nn/layers/activation_vulkan_notd_vulkan.v
@@ -1,0 +1,11 @@
+module layers
+
+import vtl
+
+pub fn relu_forward_vulkan_f32(x &vtl.Tensor[f32]) !&vtl.Tensor[f32] {
+	return error(@FN + ': compile with -d vulkan')
+}
+
+pub fn sigmoid_forward_vulkan_f32(x &vtl.Tensor[f32]) !&vtl.Tensor[f32] {
+	return error(@FN + ': compile with -d vulkan')
+}

--- a/nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v
+++ b/nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v
@@ -1,0 +1,21 @@
+module layers
+
+import math
+import os
+import vtl
+import vtl.nn.internal
+
+fn test_relu_forward_vulkan_f32_matches_cpu() ! {
+	if os.getenv('VTL_USE_VULKAN') != '1' {
+		return
+	}
+	x := vtl.from_array([f32(2), -1, 0.5, -3], [2, 2])!
+	cpu := internal.relu[f32](x)
+	gpu := relu_forward_vulkan_f32(x)!
+	for i in 0 .. cpu.shape[0] {
+		for j in 0 .. cpu.shape[1] {
+			diff := math.abs(cpu.get([i, j]) - gpu.get([i, j]))
+			assert diff < 1e-3, 'relu vulkan mismatch at [${i},${j}]: ${diff}'
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Enable GPU ReLU/Sigmoid for f32 Sequential by calling `vsl.vulkan.compute.relu_vulkan_f32` / `sigmoid_vulkan_f32` (host buffer I/O) instead of `VulkanTensor.relu()` which triggered C codegen errors under `-prod`.

- New `activation_vulkan_d_vulkan.v` + `_notd` stubs
- Re-enable `model.relu()` in `nn_cifar10_vulkan`
- Test: `activation_vulkan_relu_f32_d_vulkan_test.v`

## Test plan
- [x] `VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v`
- [x] `VTL_USE_VULKAN=1 v -prod -d vulkan run examples/nn_cifar10_vulkan/main.v` (Conv2D+ReLU+Linear)


Made with [Cursor](https://cursor.com)