### PR TITLE
refactor(nn): Adam f32 flat CPU step

### DIFF
--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -35,7 +35,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | — | Vulkan f32 activations via `relu_vulkan_f32` / `sigmoid_vulkan_f32` (compute path) |
-| P2 | — | Vulkan: Adam f32 GPU |
+| P2 | — | Vulkan Adam f32 GPU (blocked: VSL needs `vector_mul` / `sqrt` shaders; f32 Adam uses flat CPU step) |
 | P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 
 ## Local development

--- a/examples/nn_cifar10_vulkan/main.v
+++ b/examples/nn_cifar10_vulkan/main.v
@@ -11,7 +11,7 @@ import vtl.nn.optimizers
 //   v run vtl/examples/nn_cifar10_vulkan/main.v
 //   VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 //
-// Linear backward uses Vulkan GEMM when VTL_USE_VULKAN=1; Adam stays on CPU.
+// Linear/Conv2D use Vulkan GEMM when VTL_USE_VULKAN=1; Adam f32 uses flat CPU step.
 
 const batch_size = 2
 const epochs = 1

--- a/nn/optimizers/adam.v
+++ b/nn/optimizers/adam.v
@@ -112,21 +112,14 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 				o.first_moments[i] = vtl.from_array(m_arr, v.value.shape) or { return err }
 				o.second_moments[i] = vtl.from_array(v_arr, v.value.shape) or { return err }
 			} $else $if sizeof(T) == 4 {
-				o.first_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
-					return vtl.cast[T](o.beta1 * f64(vals[0]) + (1.0 - o.beta1) * f64(vals[1]))
-				}) or { return err }
-				o.second_moments[i].napply([v.grad], fn [o] [T](vals []T, idx []int) T {
-					g := f64(vals[1])
-					return vtl.cast[T](o.beta2 * f64(vals[0]) + (1.0 - o.beta2) * g * g)
-				}) or { return err }
-				m_i := o.first_moments[i]
-				v_i := o.second_moments[i]
-				v.value.napply([m_i, v_i], fn [o, lr_t] [T](vals []T, idx []int) T {
-					theta := f64(vals[0])
-					m := f64(vals[1])
-					vv := f64(vals[2])
-					return vtl.cast[T](theta - lr_t * m / (math.sqrt(vv) + o.epsilon))
-				}) or { return err }
+				grad := v.grad.to_array()
+				mut theta := v.value.to_array()
+				mut m_arr := o.first_moments[i].to_array()
+				mut v_arr := o.second_moments[i].to_array()
+				adam_step_f32_cpu(grad, mut theta, mut m_arr, mut v_arr, step)
+				v.value = vtl.from_array(theta, v.value.shape) or { return err }
+				o.first_moments[i] = vtl.from_array(m_arr, v.value.shape) or { return err }
+				o.second_moments[i] = vtl.from_array(v_arr, v.value.shape) or { return err }
 			} $else {
 				return error('AdamOptimizer.update: unsupported element type size ${sizeof(T)}')
 			}

--- a/nn/optimizers/adam_step_f32.v
+++ b/nn/optimizers/adam_step_f32.v
@@ -1,0 +1,21 @@
+module optimizers
+
+import math
+
+// adam_step_f32_cpu performs one Adam update on flat f32 buffers (same math as napply path).
+pub fn adam_step_f32_cpu(grad []f32, mut theta []f32, mut m []f32, mut v []f32, p AdamStepParams) {
+	n := grad.len
+	b1 := f32(p.beta1)
+	b2 := f32(p.beta2)
+	lr := f32(p.lr_t)
+	eps := f32(p.epsilon)
+	one_minus_b1 := f32(1.0 - p.beta1)
+	one_minus_b2 := f32(1.0 - p.beta2)
+	for i in 0 .. n {
+		g := grad[i]
+		m[i] = b1 * m[i] + one_minus_b1 * g
+		v[i] = b2 * v[i] + one_minus_b2 * g * g
+		denom := f32(math.sqrt(f64(v[i]))) + eps
+		theta[i] -= lr * m[i] / denom
+	}
+}

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -39,6 +39,21 @@ fn test_sgd_zeros_grad_after_update() ! {
 	assert g == 0.0, 'grad should be zeroed after update, got ${g}'
 }
 
+fn test_adam_step_f32_cpu_moves_theta() {
+	grad := [f32(1.0), f32(2.0)]
+	mut theta := [f32(5.0), f32(5.0)]
+	mut m := [f32(0.0), f32(0.0)]
+	mut v := [f32(0.0), f32(0.0)]
+	adam_step_f32_cpu(grad, mut theta, mut m, mut v, AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.001
+		epsilon: 1e-8
+	})
+	assert theta[0] < 5.0
+	assert m[0] > 0.0
+}
+
 fn test_adam_step_f64_cpu() {
 	grad := [1.0, 2.0]
 	mut theta := [5.0, 5.0]


### PR DESCRIPTION
## Summary
- Add `adam_step_f32_cpu` and use it in `AdamOptimizer.update` for f32.
- Same update rule as the previous `napply` path; faster for training smokes.
- Roadmap note: true Vulkan GPU Adam needs VSL `vector_mul` / `sqrt` pipelines.

## Test plan
- [x] `v test nn/optimizers/optimizer_test.v`
- [x] `v test nn/f32_training_smoke_test.v`


Made with [Cursor](https://cursor.com)