### PR TITLE
feat(nn): Vulkan GPU Adam f32

### DIFF
--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -35,7 +35,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
 | — | Vulkan f32 activations via `relu_vulkan_f32` / `sigmoid_vulkan_f32` (compute path) |
-| P2 | — | Vulkan Adam f32 GPU (blocked: VSL needs `vector_mul` / `sqrt` shaders; f32 Adam uses flat CPU step) |
+| — | Vulkan Adam f32 fused shader (`adam_step` + VSL 8 binding layout; `VTL_USE_VULKAN=1`) |
 | P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 
 ## Local development

--- a/examples/nn_cifar10_vulkan/main.v
+++ b/examples/nn_cifar10_vulkan/main.v
@@ -11,7 +11,7 @@ import vtl.nn.optimizers
 //   v run vtl/examples/nn_cifar10_vulkan/main.v
 //   VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 //
-// Linear/Conv2D use Vulkan GEMM when VTL_USE_VULKAN=1; Adam f32 uses flat CPU step.
+// Linear/Conv2D/Adam use Vulkan when VTL_USE_VULKAN=1 (-d vulkan, v -prod for GPU).
 
 const batch_size = 2
 const epochs = 1

--- a/nn/optimizers/adam.v
+++ b/nn/optimizers/adam.v
@@ -112,6 +112,18 @@ pub fn (mut o AdamOptimizer[T]) update() ! {
 				o.first_moments[i] = vtl.from_array(m_arr, v.value.shape) or { return err }
 				o.second_moments[i] = vtl.from_array(v_arr, v.value.shape) or { return err }
 			} $else $if sizeof(T) == 4 {
+				$if vulkan ? {
+					if adam_use_vulkan_optimizer() {
+						mut m_t := o.first_moments[i]
+						mut v_t := o.second_moments[i]
+						if try_adam_update_f32_vulkan(mut v, mut m_t, mut v_t, step) {
+							o.first_moments[i] = m_t
+							o.second_moments[i] = v_t
+							v.grad = vtl.zeros_like[T](v.value)
+							continue
+						}
+					}
+				}
 				grad := v.grad.to_array()
 				mut theta := v.value.to_array()
 				mut m_arr := o.first_moments[i].to_array()

--- a/nn/optimizers/adam_f32_vulkan_d_vulkan.v
+++ b/nn/optimizers/adam_f32_vulkan_d_vulkan.v
@@ -1,0 +1,45 @@
+module optimizers
+
+import os
+import vtl
+import vtl.autograd
+import vtl.storage
+import vsl.vulkan
+import vsl.vulkan.compute
+
+pub fn adam_use_vulkan_optimizer() bool {
+	return os.getenv('VTL_USE_VULKAN') == '1'
+}
+
+fn adam_vulkan_device() !&vulkan.Device {
+	mut probe := vtl.zeros[f32]([1])
+	vk := probe.vulkan(storage.VulkanParams{})!
+	defer { vk.release() }
+	return vk.data.data.device
+}
+
+// try_adam_update_f32_vulkan returns true when GPU Adam succeeded.
+pub fn try_adam_update_f32_vulkan(mut v autograd.Variable[f32], mut m_tensor vtl.Tensor[f32],
+	mut v_tensor vtl.Tensor[f32], step AdamStepParams) bool {
+	adam_update_f32_vulkan(mut v, mut m_tensor, mut v_tensor, step) or { return false }
+	return true
+}
+
+// adam_update_f32_vulkan runs fused Adam on GPU (VSL adam_step shader).
+fn adam_update_f32_vulkan(mut v autograd.Variable[f32], mut m_tensor vtl.Tensor[f32],
+	mut v_tensor vtl.Tensor[f32], step AdamStepParams) ! {
+	dev := adam_vulkan_device()!
+	grad := v.grad.to_array()
+	mut theta := v.value.to_array()
+	mut m_arr := m_tensor.to_array()
+	mut v_arr := v_tensor.to_array()
+	compute.adam_step_vulkan_f32(dev, grad, mut theta, mut m_arr, mut v_arr, compute.AdamStepParams{
+		beta1:   step.beta1
+		beta2:   step.beta2
+		lr_t:    step.lr_t
+		epsilon: step.epsilon
+	})!
+	v.value = vtl.from_array(theta, v.value.shape)!
+	m_tensor = vtl.from_array(m_arr, v.value.shape)!
+	v_tensor = vtl.from_array(v_arr, v.value.shape)!
+}

--- a/nn/optimizers/adam_f32_vulkan_d_vulkan_test.v
+++ b/nn/optimizers/adam_f32_vulkan_d_vulkan_test.v
@@ -1,0 +1,36 @@
+module optimizers
+
+import math
+import os
+import vtl
+import vtl.autograd
+
+fn test_adam_f32_vulkan_matches_cpu() ! {
+	if os.getenv('VTL_USE_VULKAN') != '1' {
+		return
+	}
+	c := autograd.ctx[f32]()
+	mut p_cpu := c.variable(vtl.from_1d([f32(5.0), f32(5.0)])!)
+	mut p_gpu := c.variable(vtl.from_1d([f32(5.0), f32(5.0)])!)
+	p_cpu.grad = vtl.from_1d([f32(1.0), f32(2.0)])!
+	p_gpu.grad = vtl.from_1d([f32(1.0), f32(2.0)])!
+	m_cpu := vtl.zeros_like[f32](p_cpu.grad)
+	v_cpu := vtl.zeros_like[f32](p_cpu.grad)
+	mut m_gpu := vtl.zeros_like[f32](p_gpu.grad)
+	mut v_gpu := vtl.zeros_like[f32](p_gpu.grad)
+	step := AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.001
+		epsilon: 1e-8
+	}
+	grad := p_cpu.grad.to_array()
+	mut th_cpu := p_cpu.value.to_array()
+	mut ma := m_cpu.to_array()
+	mut va := v_cpu.to_array()
+	adam_step_f32_cpu(grad, mut th_cpu, mut ma, mut va, step)
+	assert try_adam_update_f32_vulkan(mut p_gpu, mut m_gpu, mut v_gpu, step)
+	for i in 0 .. th_cpu.len {
+		assert math.abs(th_cpu[i] - p_gpu.value.get_nth(i)) < 1e-3
+	}
+}

--- a/nn/optimizers/adam_f32_vulkan_notd_vulkan.v
+++ b/nn/optimizers/adam_f32_vulkan_notd_vulkan.v
@@ -1,0 +1,13 @@
+module optimizers
+
+import vtl
+import vtl.autograd
+
+pub fn adam_use_vulkan_optimizer() bool {
+	return false
+}
+
+pub fn try_adam_update_f32_vulkan(mut v autograd.Variable[f32], mut m_tensor vtl.Tensor[f32],
+	mut v_tensor vtl.Tensor[f32], step AdamStepParams) bool {
+	return false
+}


### PR DESCRIPTION
## Summary
- `AdamOptimizer.update` uses GPU fused Adam when `VTL_USE_VULKAN=1` and `-d vulkan`.
- Falls back to `adam_step_f32_cpu` on error.

**Depends on:** https://github.com/vlang/vsl/pull/305 (8-binding layout + adam_step shader)

## Test plan
- [x] `VTL_USE_VULKAN=1 v -prod -d vulkan test nn/optimizers/adam_f32_vulkan_d_vulkan_test.v`
- [x] `VTL_USE_VULKAN=1 v -prod -d vulkan run examples/nn_cifar10_vulkan/main.v`


Made with [Cursor](https://cursor.com)