### PR TITLE
fix(vtl): from_array shape clone + Vulkan roadmap sync

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -93,12 +93,10 @@ See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 
 | Priority | Work item |
 |----------|-----------|
-| P1 | [#41](https://github.com/vlang/vtl/issues/41) Windows crash |
-| P2 | Label `full-ml` for optional heavy CI workflow |
-| P1 | Phases 2–4 in `DEVICE_MEMORY.md` |
-| — | Vulkan wired into training (`nn_cifar10_vulkan` f32 forward+backprop+Adam) |
-| P2 | Vulkan Conv2D forward f32 (no padding); GPU backward / activations / Adam TBD |
+| P1 | [#41](https://github.com/vlang/vtl/issues/41) Windows crash — `from_array` shape clone fix; verify on Windows |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) ARM GPU |
+| P2 | Label `full-ml` for optional heavy CI workflow |
+| P2 | Vulkan persistent GPU activation chain (optional; per-layer GPU activations work today) |
 
 **Project board:** [vlang org project #8](https://github.com/orgs/vlang/projects/8)
 
@@ -108,7 +106,7 @@ See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 
 | # | Title | Priority | Notes |
 |---|-------|----------|-------|
-| [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash | 🔴 P1 | |
+| [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash | 🔴 P1 | shape.clone in `from_array` (needs Win CI) |
 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support | 🟡 P2 | Open |
 | [#43](https://github.com/vlang/vtl/issues/43) | `stats.to_array` performance | 🟡 Medium | |
 | [#40](https://github.com/vlang/vtl/issues/40) | YOLO for autograd gates | 🟡 Medium | |

--- a/build.v
+++ b/build.v
@@ -26,9 +26,10 @@ pub fn from_array[T](arr []T, shape []int, params TensorData) !&Tensor[T] {
 			data:    data_storage
 		}
 	}
-	strides := strides_from_shape(shape, params.memory)
+	sh := shape.clone()
+	strides := strides_from_shape(sh, params.memory)
 	return &Tensor[T]{
-		shape:   shape
+		shape:   sh
 		strides: strides
 		memory:  params.memory
 		size:    size

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -56,3 +56,12 @@ mut model := models.sequential_from_ctx[f64](ctx)
 - **Phase 4**: Adam on GPU with persistent m/v/θ in `DeviceSession` (#106, #111 follow-up)
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.
+
+## Vulkan (f32, opt-in)
+
+| Variable | Effect |
+|----------|--------|
+| `VTL_USE_VULKAN=1` | GPU forward/backward for Linear, Conv2D (same-padding), ReLU/Sigmoid, Adam |
+| `VTL_TEST_VULKAN=1` | Run Vulkan integration tests |
+
+Build: `-d vulkan` and `v -prod` for GPU execution. Tensors remain CPU-backed; ops sync via host buffers (same policy as CUDA Phase 1).

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -21,8 +21,8 @@ or `v test vtl` can spike **RAM into the 10–20+ GB** range during compilation 
 | `VTL_CUDA_BACKWARD` | off | Phase 3: cuBLAS GEMM for Linear gate backward. |
 | `VTL_CUDA_OPTIMIZER` | off | Phase 4: cuBLAS moment updates for Adam. |
 | `VTL_TEST_CUDA` | off | Set to `1` to run GPU tests (`linear_cuda_test.v`, `device_session_test.v`). |
-| `VTL_USE_VULKAN` | off | f32 Linear forward/backward via Vulkan (`-d vulkan` build). Use `v -prod` for GPU (debug instance crash on V 0.5.1). |
-| `VTL_TEST_VULKAN` | off | Optional Vulkan integration tests. |
+| `VTL_USE_VULKAN` | off | f32 Linear/Conv2D/activations/Adam via Vulkan (`-d vulkan`). Use `v -prod` for GPU (debug instance crash on V 0.5.1). |
+| `VTL_TEST_VULKAN` | off | Optional Vulkan integration tests (conv2d, activations, Adam, training smoke). |
 | `VJOBS` | (V auto) | Cap parallel compile jobs, e.g. `VJOBS=2`. |
 
 CUDA is **opt-in** so normal CPU work never touches the GPU driver.
@@ -53,12 +53,19 @@ VJOBS=2 v test vtl/autograd/device_session_test.v
 # VSL CUDA ops (one file)
 VJOBS=1 v -d cuda test vsl/cuda/examples/cuda_ops_test.v
 
-# Vulkan f32 training (CPU path; no SDK required)
+# Vulkan f32 (CPU compile path without SDK)
 VJOBS=2 v test vtl/nn/layers/linear_vulkan_integration_test.v
 v run vtl/examples/nn_cifar10_vulkan/main.v
-# VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
-# VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v vtl/nn/internal/conv2d_vulkan_backward_f32_d_vulkan_test.v
-# VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v
+
+# Vulkan f32 GPU full stack (Linear + Conv2D + ReLU + Adam)
+VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
+VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/f32_vulkan_training_smoke_test_d_vulkan.v
+VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test \
+  vtl/nn/internal/conv2d_vulkan_forward_f32_d_vulkan_test.v \
+  vtl/nn/internal/conv2d_vulkan_backward_f32_d_vulkan_test.v \
+  vtl/nn/layers/activation_vulkan_relu_f32_d_vulkan_test.v \
+  vtl/nn/optimizers/adam_f32_vulkan_d_vulkan_test.v
+VSL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test vsl/vulkan/compute/adam_step_vulkan_test.v
 ```
 
 ## CI split (implemented, #109)

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -6,7 +6,7 @@ Detailed roadmap: [ROADMAP.md](../ROADMAP.md)
 
 GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 
-## Done (2026-05-31)
+## Done (2026-06-01)
 
 | Issue | Topic |
 |-------|--------|
@@ -21,22 +21,24 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#116](https://github.com/vlang/vtl/issues/116) | f32 autograd: `Sequential` + MSE forward/backprop compile |
 | — | f32 tiny training: `nn_cifar10_f32_tiny_synth` + `f32_training_smoke_test` |
 | — | CUDA training smoke: `nn_cifar10_cuda` + `nn/cuda_training_smoke_test` |
-| — | f32 Vulkan training: `nn_cifar10_vulkan` + `nn_cifar10_f32_vulkan_tiny_synth` + `f32_vulkan_training_smoke_test` (forward + backward GEMM) |
-| — | Vulkan Conv2D f32 forward/backward (same-padding): im2col+GEMM; backward `d_weight` GEMM layout fix in VSL |
+| — | f32 Vulkan training: `nn_cifar10_vulkan` + `f32_vulkan_training_smoke_test` |
+| — | Vulkan Conv2D f32 forward/backward (same-padding, im2col+GEMM) |
+| — | Vulkan ReLU/Sigmoid f32 (`relu_vulkan_f32` / `sigmoid_vulkan_f32`) |
+| — | Vulkan Adam f32 fused shader (`VTL_USE_VULKAN=1`, VSL `adam_step`) |
 | — | Conv2D autograd: register weight/bias parents (`conv2d_autograd_smoke_test`) |
 | [#86](https://github.com/vlang/vtl/issues/86) | `DataLoader` |
+| — | `from_array` clones shape (fixes [#41](https://github.com/vlang/vtl/issues/41) aliasing) |
 
-**VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285).
+**VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285), [#304](https://github.com/vlang/vsl/pull/304) conv2d backward GEMM, [#305](https://github.com/vlang/vsl/pull/305) Adam shaders.
 
 ## Critical path (open)
 
 | Priority | Issue | Topic |
 |----------|-------|--------|
-| P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash |
+| P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash — shape clone landed; needs Windows CI confirmation |
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
-| — | Vulkan f32 activations via `relu_vulkan_f32` / `sigmoid_vulkan_f32` (compute path) |
-| — | Vulkan Adam f32 fused shader (`adam_step` + VSL 8 binding layout; `VTL_USE_VULKAN=1`) |
 | P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
+| P2 | — | Vulkan: persistent GPU activation chain between layers (CUDA has `VTL_GPU_ACTIVATIONS`) |
 
 ## Local development
 
@@ -48,11 +50,8 @@ cd ~/.vmodules
 v test vtl/nn vtl/datasets
 v run vtl/examples/nn_cifar10_tiny_synth/main.v
 v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
-# CUDA (opt-in)
-# VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
-# Vulkan f32 Linear forward smoke
-# v run vtl/examples/nn_cifar10_vulkan/main.v
-# VTL_USE_VULKAN=1 v -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
+# Vulkan f32 full stack (use -prod for GPU)
+# VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 ```
 
 ## CI

--- a/tests/core/creation_test.v
+++ b/tests/core/creation_test.v
@@ -125,6 +125,15 @@ fn test_from_1d() {
 	assert t.array_equal(expected)
 }
 
+// Regression for #41: shape slice must be owned (Windows heap corruption if aliased).
+fn test_from_array_shape_not_aliased() {
+	mut sh := [4]
+	t := vtl.from_array([f32(1), 2, 3, 4], sh)!
+	sh[0] = 99
+	assert t.shape[0] == 4
+	assert t.get_nth(3) == 4
+}
+
 fn test_from_2d() {
 	t := vtl.from_2d[f64]([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])!
 	expected := vtl.from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], [2, 3])!


### PR DESCRIPTION
## Summary
- **#41:** `from_array` now clones `shape` (matches `tensor()`); regression test `test_from_array_shape_not_aliased`.
- Docs: Vulkan stack marked done in ML_ROADMAP; trim stale TBD items in ROADMAP; DEV_LIGHTWEIGHT full Vulkan test commands.

## Test plan
- [x] `v test tests/core/creation_test.v`
- [x] Vulkan scoped tests (conv2d, Adam, training smoke)


Made with [Cursor](https://cursor.com)