### PR TITLE
docs: refresh VTL ML release documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 and machine learning — n-dimensional arrays, autograd, linear algebra via
 [VSL](https://github.com/vlang/vsl), and a full neural network module.
 
+Train small neural networks, experiment with autograd, and use VSL-backed CPU,
+CUDA, and Vulkan compute paths from one V-native API.
+
 [vlang.io](https://vlang.io) |
 [Docs](https://vlang.github.io/vtl) |
 [Tutorials](docs/TUTORIAL.md) |
@@ -39,11 +42,23 @@ t.get([1, 1])
 - **Neural networks** — `Sequential` API; Linear, Conv2D, LSTM, Attention, …
 - **Losses & optimizers** — MSE, BCE, CrossEntropy, Huber; Adam, AdamW, SGD, …
 - **Linear algebra** — VSL-backed matmul, solve, QR, LU, Cholesky, SVD, pinv
-- **Hardware** — zero-copy `Tensor.data` for C libs; optional CUDA paths
+- **Hardware** — zero-copy `Tensor.data` for C libs; optional CUDA and Vulkan training paths
+
+## ML Release Highlights
+
+| Area | Status |
+|------|--------|
+| f32 training | `Sequential` + MSE + Adam smoke tests |
+| CUDA | Linear/Conv2D forward, CUDA backward, GPU activation chain, Adam optimizer slots |
+| Vulkan | f32 Linear, Conv2D same-padding, ReLU/Sigmoid, fused Adam shader |
+| Datasets | MNIST, IMDB, CIFAR-10 loaders plus CI-safe synthetic examples |
+| Benchmarks | VTL vs NumPy/PyTorch scripts and PR benchmark workflow |
+
+For memory-safe local commands, see [DEV_LIGHTWEIGHT.md](docs/DEV_LIGHTWEIGHT.md).
 
 ## Quick start
 
-```v
+```v ignore
 import vtl
 import vtl.autograd
 import vtl.nn.layers
@@ -104,6 +119,18 @@ v test ~/.vmodules/vtl
 See [DEV_LIGHTWEIGHT.md](docs/DEV_LIGHTWEIGHT.md) for memory-safe subsets in CI.
 
 ## Documentation
+
+### Start Here
+
+| Goal | Read |
+|------|------|
+| Learn tensors | [First steps](docs/TUTORIAL_FIRST_STEPS.md) |
+| Learn autograd | [Autograd tutorial](docs/TUTORIAL_AUTOGRAD.md) |
+| Build neural networks | [Neural networks](docs/TUTORIAL_NEURAL_NETWORKS.md) |
+| Pick optimizers | [Optimizers](docs/TUTORIAL_OPTIMIZERS.md) |
+| Run examples | [Examples catalog](examples/README.md) |
+| Use datasets | [Datasets](datasets/README.md) |
+| Use GPU paths safely | [DEV_LIGHTWEIGHT.md](docs/DEV_LIGHTWEIGHT.md), [DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md) |
 
 | Tutorial | Topic |
 |----------|-------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,7 +39,7 @@
 - [x] Issue [#62](https://github.com/vlang/vtl/issues/62) — Phase 5: OpenCL Backend (VCL unified into Compute abstraction)
 
 ### Phase 6 — ARM GPU Support
-- [x] Issue [#63](https://github.com/vlang/vtl/issues/63) — Phase 6: ARM GPU Support (Android, iOS, Embedded)
+- [ ] Issue [#63](https://github.com/vlang/vtl/issues/63) — Phase 6: ARM GPU Support (Android, iOS, Embedded)
 
 ### Phase 7+ — Performance Engineering
 - [x] Issue [#64](https://github.com/vlang/vtl/issues/64) — Phase 7+: Kernel Fusion, Mixed Precision, Computation Graph Optimization
@@ -75,7 +75,7 @@
 
 ### Phase E — Example Consolidation
 - [x] `nn_cifar10_cuda` — opt-in CUDA smoke (`VTL_USE_CUDA=1`, `-d cuda`)
-- [x] `nn_cifar10_vulkan` — f32 smoke + `linear_forward_vulkan` check
+- [x] `nn_cifar10_vulkan` — f32 smoke with Vulkan Linear, Conv2D, ReLU/Sigmoid, Adam
 - [x] Root `README.md` passes `v check-md -hide-warnings`
 - [x] All example READMEs pass `v check-md -hide-warnings`
 
@@ -98,7 +98,7 @@ See [docs/DEVICE_MEMORY.md](docs/DEVICE_MEMORY.md).
 | P2 | Label `full-ml` for optional heavy CI workflow |
 | P2 | Vulkan persistent GPU activation chain (optional; per-layer GPU activations work today) |
 
-**Project board:** [vlang org project #8](https://github.com/orgs/vlang/projects/8)
+**Maintainer project board:** [vlang org project #8](https://github.com/orgs/vlang/projects/8) (may require access)
 
 ---
 
@@ -205,4 +205,4 @@ vtl/
 
 ---
 
-*Last updated: 2026-05-31* · Board: [project #8](https://github.com/orgs/vlang/projects/8)
+*Last updated: 2026-05-31* · Maintainer board: [project #8](https://github.com/orgs/vlang/projects/8)

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,17 +10,20 @@ v run vtl/benchmarks/vs_numpy/matmul_bench.v
 v run vtl/benchmarks/vs_numpy/conv2d_bench.v
 ```
 
-CUDA matmul (when wired):
+CUDA/Vulkan paths are opt-in:
 
 ```bash
 VTL_USE_CUDA=1 v -d cuda run vtl/benchmarks/vs_numpy/matmul_bench.v
+VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/benchmarks/vs_numpy/matmul_bench.v
 ```
 
-## NumPy reference
+## NumPy / PyTorch reference
 
-See [vs_numpy/README.md](vs_numpy/README.md) for copy-paste Python `%timeit` commands.
+See [vs_numpy/README.md](vs_numpy/README.md) for Python reference commands
+and result reporting guidance.
 
 ## CI
 
-Full GH Actions benchmark comment workflow is tracked in [#88](https://github.com/vlang/vtl/issues/88)
-(Phase D). This directory provides the runnable scripts and GFLOPS reporting.
+The benchmark comment workflow from [#88](https://github.com/vlang/vtl/issues/88)
+is available for PR evidence. Keep local runs scoped; full benchmark suites are
+hardware-sensitive and should not be part of default development loops.

--- a/benchmarks/vs_numpy/README.md
+++ b/benchmarks/vs_numpy/README.md
@@ -35,3 +35,15 @@ python3 vtl/benchmarks/vs_numpy/pytorch_baseline.py autograd
 - Use the same matrix sizes when comparing manually.
 - Report GFLOPS from the VTL script output for PR comments.
 - CUDA paths require `VTL_USE_CUDA=1` and `-d cuda` where applicable.
+- Vulkan paths require `VTL_USE_VULKAN=1`, `-d vulkan`, and usually `v -prod`.
+- Autograd comparisons use PyTorch as the reference; record CPU/GPU model and flags.
+
+## Suggested report fields
+
+| Field | Example |
+|-------|---------|
+| Operation | `matmul`, `conv2d`, `autograd` |
+| Backend | CPU, CUDA, Vulkan |
+| Shape | Matrix size or model dimensions |
+| V flags | `-d cuda`, `-d vulkan`, `-prod` |
+| Baseline | NumPy or PyTorch timing |

--- a/datasets/README.md
+++ b/datasets/README.md
@@ -1,8 +1,33 @@
 # VTL Datasets
 
-This module exposes some functionalities to download and use the VTL datasets.
-For this we created some batch based iterators to load the datasets.
-We expose the following datasets:
+VTL provides dataset loaders and batching utilities for ML examples and tests.
 
-- **Mnist**: A dataset of handwritten digits.
-- **Imdb**: A dataset of IMDB reviews for sentiment analysis.
+## Available datasets
+
+| Dataset | Loader | Purpose |
+|---------|--------|---------|
+| MNIST | `datasets.load_mnist()` | Handwritten digit images (`28x28`) |
+| IMDB | `datasets.load_imdb()` | Sentiment analysis reviews |
+| CIFAR-10 | `datasets.load_cifar10(...)` | Image classification examples |
+| DataLoader | `datasets.DataLoader[T]` | Batch, shuffle, and iterate tensors/labels |
+
+## Examples
+
+Run from `~/.vmodules`:
+
+```bash
+v run vtl/examples/datasets_mnist/main.v
+v run vtl/examples/datasets_imdb/main.v
+v run vtl/examples/nn_cifar10_tiny_synth/main.v
+```
+
+Use synthetic examples (`nn_cifar10_tiny_synth`,
+`nn_cifar10_f32_tiny_synth`) for CI and quick local checks. Real dataset
+examples may download/cache data and should be treated as local integration
+tests.
+
+## Related docs
+
+- [Examples catalog](../examples/README.md)
+- [Neural network tutorial](../docs/TUTORIAL_NEURAL_NETWORKS.md)
+- [Lightweight development commands](../docs/DEV_LIGHTWEIGHT.md)

--- a/docs/DEVICE_MEMORY.md
+++ b/docs/DEVICE_MEMORY.md
@@ -1,18 +1,19 @@
-# Device memory model (VTL autograd + CUDA)
+# Device memory model (VTL autograd + GPU backends)
 
 Status: **Phase 1** complete · **Phase 2** done (`VTL_GPU_ACTIVATIONS=1`, #101/#104) ·
-**Phase 3** opt-in (`VTL_CUDA_BACKWARD=1`) — Linear backward GEMMs on GPU when enabled.
+**Phase 3** done (`VTL_CUDA_BACKWARD=1`) · **Phase 4** done
+(`VTL_CUDA_OPTIMIZER=1`) · Vulkan f32 training path done (`VTL_USE_VULKAN=1`).
 
 ## Policy
 
 | Stage | Where data lives | Why |
 |-------|------------------|-----|
-| Parameters (weights, bias) | CPU (`CpuStorage`) | Optimizers and gates use CPU matmul today |
-| Forward (Linear/Conv2D) | Compute on GPU when `VTL_USE_CUDA=1` | cuBLAS/cuDNN |
+| Parameters (weights, bias) | CPU (`CpuStorage`) | Stable serialization/autograd interface |
+| Forward (Linear/Conv2D) | Compute on GPU when enabled | CUDA cuBLAS/cuDNN or Vulkan GEMM/im2col |
 | Forward output | **CPU tensor** | `Variable` and gates expect `CpuStorage` |
-| Backward | CPU by default; GPU when `VTL_CUDA_BACKWARD=1` | Linear cuBLAS; Conv2D cuDNN (eligible config) |
-| Optimizer (Adam) | CPU by default; GPU + persistent slots when `VTL_CUDA_OPTIMIZER=1` | `DeviceOptimizerState` per param |
-| Optimizer step | CPU | unchanged |
+| Backward | CPU by default; GPU when eligible | CUDA Linear/Conv2D; Vulkan Linear/Conv2D `d_weight` |
+| Optimizer (Adam) | CPU by default; GPU when enabled | CUDA persistent slots; Vulkan fused f32 shader |
+| Optimizer step | CPU sync result | Host tensors remain canonical |
 
 Sync points (host ↔ device) per Linear forward today:
 
@@ -31,8 +32,11 @@ Phase 1 removes redundant **allocations** via `DeviceSession` buffer reuse on th
 | `VTL_CUDA_BACKWARD=1` | Phase 3: cuBLAS GEMM for Linear gate backward |
 | `VTL_CUDA_OPTIMIZER=1` | Phase 4: cuBLAS moment updates for Adam |
 | `VTL_TEST_CUDA=1` | Run GPU tests |
+| `VTL_USE_VULKAN=1` | f32 Linear/Conv2D/ReLU/Sigmoid/Adam via Vulkan |
+| `VTL_TEST_VULKAN=1` | Run Vulkan integration tests |
 
-Build: `-d cuda` required for GPU code paths.
+Build: `-d cuda` or `-d vulkan` required for GPU code paths. Use `v -prod`
+with Vulkan on machines where debug instance creation is unstable.
 
 ## API
 
@@ -53,7 +57,7 @@ mut model := models.sequential_from_ctx[f64](ctx)
 
 - **Phase 2**: GPU-resident `Variable` (`gpu_activation`, #101) — done (#104)
 - **Phase 3**: CUDA backward for Linear + Conv2D (opt-in `VTL_CUDA_BACKWARD`) — done (#107)
-- **Phase 4**: Adam on GPU with persistent m/v/θ in `DeviceSession` (#106, #111 follow-up)
+- **Phase 4**: Adam on GPU with persistent m/v/θ in `DeviceSession` — done
 
 See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.
 
@@ -64,4 +68,14 @@ See [DEV_LIGHTWEIGHT.md](DEV_LIGHTWEIGHT.md) for safe test commands.
 | `VTL_USE_VULKAN=1` | GPU forward/backward for Linear, Conv2D (same-padding), ReLU/Sigmoid, Adam |
 | `VTL_TEST_VULKAN=1` | Run Vulkan integration tests |
 
-Build: `-d vulkan` and `v -prod` for GPU execution. Tensors remain CPU-backed; ops sync via host buffers (same policy as CUDA Phase 1).
+Build: `-d vulkan` and `v -prod` for GPU execution. Tensors remain
+CPU-backed; ops sync via host buffers (same policy as CUDA Phase 1).
+
+Current Vulkan f32 stack:
+
+| Component | GPU path |
+|-----------|----------|
+| Linear forward/backward | VSL Vulkan GEMM |
+| Conv2D forward/backward | VSL Vulkan im2col + GEMM (same-padding) |
+| ReLU/Sigmoid | VSL Vulkan compute shaders |
+| Adam | VSL Vulkan fused `adam_step` shader |

--- a/docs/DEV_LIGHTWEIGHT.md
+++ b/docs/DEV_LIGHTWEIGHT.md
@@ -42,7 +42,7 @@ VJOBS=1 v test vtl/nn/f32_training_smoke_test.v vtl/nn/f32_autograd_smoke_test.v
 VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/nn/cuda_training_smoke_test.v
 VTL_USE_CUDA=1 VJOBS=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v
 VJOBS=2 v run vtl/examples/nn_cifar10_f32_vulkan_tiny_synth/main.v
-# VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 VJOBS=1 v -d vulkan test vtl/nn/f32_vulkan_training_smoke_test.v
+# VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/f32_vulkan_training_smoke_d_vulkan_test.v
 
 # Single-file CUDA test (only when you want GPU)
 VTL_USE_CUDA=1 VTL_TEST_CUDA=1 VJOBS=1 v -d cuda test vtl/nn/layers/linear_cuda_test.v
@@ -70,6 +70,8 @@ VSL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test vsl/vulkan/compute/adam_step_vu
 
 ## CI split (implemented, #109)
 
-- **PR default (`ci.yml`):** `bin/test` — scoped `v test` (nn, autograd, datasets, …) + compile examples except `nn_cifar10/main.v` + run `nn_cifar10_tiny_synth` and `nn_cifar10_f32_tiny_synth`
-- **Label `full-ml`:** workflow `ci-full-ml.yml` — `bin/test --full` (weekly schedule + manual dispatch)
+- **PR default (`ci.yml`):** `bin/test` — scoped `v test`, compile examples
+  except `nn_cifar10/main.v`, and run tiny synthetic CIFAR examples.
+- **Label `full-ml`:** workflow `ci-full-ml.yml` — `bin/test --full`
+  (weekly schedule + manual dispatch)
 - **Local full suite:** `VJOBS=1 ~/.vmodules/vtl/bin/test --full`

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -1,6 +1,6 @@
 # VTL — ML Roadmap & Launch Tracking
 
-Central planning: **https://github.com/orgs/vlang/projects/8** (Vlang ML Roadmap — VSL + VTL)
+Maintainer planning: **https://github.com/orgs/vlang/projects/8** (Vlang ML Roadmap — VSL + VTL; may require project access)
 
 Detailed roadmap: [ROADMAP.md](../ROADMAP.md)
 
@@ -21,7 +21,7 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 | [#116](https://github.com/vlang/vtl/issues/116) | f32 autograd: `Sequential` + MSE forward/backprop compile |
 | — | f32 tiny training: `nn_cifar10_f32_tiny_synth` + `f32_training_smoke_test` |
 | — | CUDA training smoke: `nn_cifar10_cuda` + `nn/cuda_training_smoke_test` |
-| — | f32 Vulkan training: `nn_cifar10_vulkan` + `f32_vulkan_training_smoke_test` |
+| — | f32 Vulkan training: `nn_cifar10_vulkan` + `f32_vulkan_training_smoke_d_vulkan_test` |
 | — | Vulkan Conv2D f32 forward/backward (same-padding, im2col+GEMM) |
 | — | Vulkan ReLU/Sigmoid f32 (`relu_vulkan_f32` / `sigmoid_vulkan_f32`) |
 | — | Vulkan Adam f32 fused shader (`VTL_USE_VULKAN=1`, VSL `adam_step`) |
@@ -52,6 +52,7 @@ v run vtl/examples/nn_cifar10_tiny_synth/main.v
 v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
 # Vulkan f32 full stack (use -prod for GPU)
 # VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
+# VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/f32_vulkan_training_smoke_d_vulkan_test.v
 ```
 
 ## CI

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Documentation
+# VTL Documentation
 
 <p align="center">
   <a href="https://github.com/vlang/vtl">VTL</a> · <a href="https://github.com/vlang/vsl">VSL</a>
@@ -12,29 +12,50 @@ VTL is a pure-V tensor library for numerical computing and machine learning.
 It provides n-dimensional arrays, automatic differentiation (autograd), and a full
 neural network module.
 
+## Start Here
+
+| Goal | Read |
+|------|------|
+| New to VTL | [Tutorial overview](./TUTORIAL.md) |
+| Tensor creation, indexing, slicing | [First steps](./TUTORIAL_FIRST_STEPS.md), [Slicing](./TUTORIAL_SLICING.md) |
+| Broadcasting, maps, reductions | [Broadcasting](./TUTORIAL_BROADCASTING.md), [Map/reduce](./TUTORIAL_MAP_REDUCE.md), [Reductions](./TUTORIAL_REDUCTIONS.md) |
+| Linear algebra | [Linear algebra](./TUTORIAL_LINEAR_ALGEBRA.md), [Advanced LA](./TUTORIAL_ADVANCED_LA.md) |
+| Autograd | [Autograd](./TUTORIAL_AUTOGRAD.md) |
+| Neural networks | [Neural networks](./TUTORIAL_NEURAL_NETWORKS.md), [Optimizers](./TUTORIAL_OPTIMIZERS.md) |
+| Datasets and examples | [Datasets](../datasets/README.md), [Examples catalog](../examples/README.md) |
+| GPU/dev workflow | [Device memory](./DEVICE_MEMORY.md), [Lightweight development](./DEV_LIGHTWEIGHT.md) |
+| Release status | [ML Roadmap](./ML_ROADMAP.md), [Project roadmap](../ROADMAP.md) |
+
+## Learning Path
+
+1. [First Steps](./TUTORIAL_FIRST_STEPS.md)
+2. [Slicing](./TUTORIAL_SLICING.md)
+3. [Broadcasting](./TUTORIAL_BROADCASTING.md)
+4. [Map and Reduce](./TUTORIAL_MAP_REDUCE.md)
+5. [Reductions](./TUTORIAL_REDUCTIONS.md)
+6. [Matrix and Vector Operations](./TUTORIAL_LINEAR_ALGEBRA.md)
+7. [Advanced Linear Algebra](./TUTORIAL_ADVANCED_LA.md)
+8. [Automatic Differentiation](./TUTORIAL_AUTOGRAD.md)
+9. [Neural Networks](./TUTORIAL_NEURAL_NETWORKS.md)
+10. [Optimizers](./TUTORIAL_OPTIMIZERS.md)
+
+## ML Release Docs
+
 | Document | Description |
 |----------|-------------|
-| [TUTORIAL.md](./TUTORIAL.md) | General overview and getting started |
-| [TUTORIAL_FIRST_STEPS.md](./TUTORIAL_FIRST_STEPS.md) | Tensor creation, indexing, slicing |
-| [TUTORIAL_MAP_REDUCE.md](./TUTORIAL_MAP_REDUCE.md) | Element-wise `map` / `nmap` and reductions |
-| [TUTORIAL_AUTOGRAD.md](./TUTORIAL_AUTOGRAD.md) | Autograd: `Variable`, gates, backprop |
-| [TUTORIAL_NEURAL_NETWORKS.md](./TUTORIAL_NEURAL_NETWORKS.md) | Layers, losses, optimizers, `Sequential` |
-| [TUTORIAL_LINEAR_ALGEBRA.md](./TUTORIAL_LINEAR_ALGEBRA.md) | LA basics via VSL |
-| [TUTORIAL_BROADCASTING.md](./TUTORIAL_BROADCASTING.md) | Broadcasting rules |
-| [TUTORIAL_SLICING.md](./TUTORIAL_SLICING.md) | Slicing and views |
-| [TUTORIAL_REDUCTIONS.md](./TUTORIAL_REDUCTIONS.md) | argmax/argmin/cumsum/cumprod |
-| [TUTORIAL_ADVANCED_LA.md](./TUTORIAL_ADVANCED_LA.md) | trace/norm/outer/qr/lu/cholesky/pinv |
-| [TUTORIAL_OPTIMIZERS.md](./TUTORIAL_OPTIMIZERS.md) | Adam/AdamW/RMSProp/AdaGrad/SGD + schedulers |
+| [ML_ROADMAP.md](./ML_ROADMAP.md) | Current ML release status and open items |
+| [DEVICE_MEMORY.md](./DEVICE_MEMORY.md) | CUDA/Vulkan memory and sync model |
+| [DEV_LIGHTWEIGHT.md](./DEV_LIGHTWEIGHT.md) | Safe commands for local work and CI |
+| [VSL_VTL_CUDA.md](./VSL_VTL_CUDA.md) | CUDA integration notes between VSL and VTL |
 
-## VSL — V Standard Library
+## VSL Relationship
 
-VSL is the pure-V linear algebra companion of VTL. It wraps LAPACK via `go-vlang/vsl`
-and provides matrix operations, decompositions, and random number generation.
+VSL is the scientific and GPU compute foundation for VTL. VTL automatically uses
+VSL for linear algebra and backend kernels where available. Install/import VSL
+directly when you need standalone scientific computing; use VTL when you need
+tensors, autograd, datasets, layers, losses, optimizers, and training loops.
 
-> **VTL automatically uses VSL as its LA backend.** There is usually no need to
-> install or import VSL directly when working with VTL.
-
-| Document | Description |
-|----------|-------------|
+| Resource | Link |
+|----------|------|
 | VSL README | [vlang/vsl](https://github.com/vlang/vsl) |
 | VSL docs | [vlang.github.io/vsl](https://vlang.github.io/vsl) |

--- a/docs/TUTORIAL.md
+++ b/docs/TUTORIAL.md
@@ -1,9 +1,30 @@
 # Tutorial
 
-- [First Steps](./TUTORIAL_FIRST_STEPS.md)
-- [Slicing](./TUTORIAL_SLICING.md)
-- [Matrix and Vector operations](./TUTORIAL_LINEAR_ALGEBRA.md)
-- [Broadcasting](./TUTORIAL_BROADCASTING.md)
-- [Map and Reduce](./TUTORIAL_MAP_REDUCE.md)
-- [Automatic Differentiation](./TUTORIAL_AUTOGRAD.md)
-- [Neural Networks](./TUTORIAL_NEURAL_NETWORKS.md)
+This is the recommended learning path for VTL. It starts with tensors, then
+builds toward autograd, neural networks, optimizers, and GPU-backed examples.
+
+## Tensor fundamentals
+
+1. [First Steps](./TUTORIAL_FIRST_STEPS.md) — creation, indexing, shapes.
+2. [Slicing](./TUTORIAL_SLICING.md) — views and sub-tensors.
+3. [Broadcasting](./TUTORIAL_BROADCASTING.md) — shape-compatible operations.
+4. [Map and Reduce](./TUTORIAL_MAP_REDUCE.md) — element-wise transforms and reductions.
+5. [Reductions](./TUTORIAL_REDUCTIONS.md) — argmax, argmin, cumulative operations.
+
+## Linear algebra
+
+6. [Matrix and Vector operations](./TUTORIAL_LINEAR_ALGEBRA.md) — VSL-backed LA.
+7. [Advanced Linear Algebra](./TUTORIAL_ADVANCED_LA.md) — QR, LU, Cholesky, pinv.
+
+## Machine learning
+
+8. [Automatic Differentiation](./TUTORIAL_AUTOGRAD.md) — `Variable`, gates, backprop.
+9. [Neural Networks](./TUTORIAL_NEURAL_NETWORKS.md) — layers, losses, `Sequential`.
+10. [Optimizers](./TUTORIAL_OPTIMIZERS.md) — SGD, Adam, AdamW, schedulers.
+
+## Next
+
+- [Examples catalog](../examples/README.md)
+- [Datasets](../datasets/README.md)
+- [Device memory and GPU paths](./DEVICE_MEMORY.md)
+- [Safe local development commands](./DEV_LIGHTWEIGHT.md)

--- a/docs/VSL_VTL_CUDA.md
+++ b/docs/VSL_VTL_CUDA.md
@@ -6,7 +6,9 @@ VTL `-d cuda` builds require a recent **vsl** with public CUDA memcpy kind const
 
 In `vsl/cuda/_cfun.c.v`:
 
-- `pub const cuda_memcpy_host_to_device`, `cuda_memcpy_device_to_host`, `cuda_memcpy_device_to_device`
+- `pub const cuda_memcpy_host_to_device`
+- `pub const cuda_memcpy_device_to_host`
+- `pub const cuda_memcpy_device_to_device`
 - `#flag` defines all three kinds for the C preprocessor (`-Dcuda_memcpy_device_to_device=4`)
 
 In `vsl/cuda/compute/optimizer_gpu.v`:
@@ -21,6 +23,7 @@ VTL_USE_CUDA=1 VJOBS=1 v -d cuda test nn/layers/linear_cuda_test.v
 VTL_USE_CUDA=1 VJOBS=1 v -d cuda run examples/nn_cifar10_cuda/main.v
 ```
 
-## Pin
+## Status
 
-After VSL merges `fix/pub-cuda-memcpy-kinds`, bump the vsl revision in the vtl module manifest if applicable.
+The public memcpy kind constants are available in VSL main. Keep this note as a
+compatibility checklist for users pinning older VSL revisions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,68 @@
+# VTL Examples
+
+Run examples from `~/.vmodules` unless a README says otherwise:
+
+```bash
+v run vtl/examples/nn_xor/main.v
+```
+
+Some examples download datasets or require GPU build flags. Use the synthetic
+CIFAR examples for CI-safe checks.
+
+## Tensor and autograd basics
+
+| Example | What it shows | Command |
+|---------|---------------|---------|
+| [vtl_basic_usage](./vtl_basic_usage) | Tensor creation and basic operations | `v run vtl/examples/vtl_basic_usage/main.v` |
+| [vtl_vandermont](./vtl_vandermont) | Matrix construction and LA utilities | `v run vtl/examples/vtl_vandermont/main.v` |
+| [autograd_backprop](./autograd_backprop) | Manual autograd/backprop flow | `v run vtl/examples/autograd_backprop/main.v` |
+
+## Neural networks
+
+| Example | What it shows | Notes |
+|---------|---------------|-------|
+| [nn_xor](./nn_xor) | Small XOR classifier | Fast CPU smoke |
+| [nn_simple_two_layer](./nn_simple_two_layer) | Basic MLP | Fast CPU smoke |
+| [nn_regression_sine](./nn_regression_sine) | Regression with synthetic data | CPU |
+| [nn_multiclass_iris](./nn_multiclass_iris) | Multiclass classifier | CPU |
+| [nn_autoencoder_simple](./nn_autoencoder_simple) | Simple autoencoder | CPU |
+| [nn_mnist](./nn_mnist) | MNIST training path | Dataset download/cache |
+
+## CIFAR-10 release examples
+
+| Example | Purpose | Recommended use |
+|---------|---------|-----------------|
+| [nn_cifar10_tiny_synth](./nn_cifar10_tiny_synth) | Synthetic f64 CIFAR-shaped smoke | CI/default |
+| [nn_cifar10_f32_tiny_synth](./nn_cifar10_f32_tiny_synth) | Synthetic f32 training smoke | CI/default |
+| [nn_cifar10_safe](./nn_cifar10_safe) | Safer real-data config | Local |
+| [nn_cifar10_tiny](./nn_cifar10_tiny) | Tiny real CIFAR subset | Local |
+| [nn_cifar10](./nn_cifar10) | Full CIFAR path with checkpoints | Local/high RAM |
+
+## GPU examples
+
+| Example | Backend | Command |
+|---------|---------|---------|
+| [nn_cifar10_cuda](./nn_cifar10_cuda) | CUDA/cuBLAS/cuDNN via VSL | `VTL_USE_CUDA=1 v -d cuda run vtl/examples/nn_cifar10_cuda/main.v` |
+| [nn_cifar10_vulkan](./nn_cifar10_vulkan) | Vulkan f32 Linear/Conv2D/ReLU/Adam via VSL | `VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v` |
+| [nn_cifar10_f32_vulkan_tiny_synth](./nn_cifar10_f32_vulkan_tiny_synth) | f32 Vulkan-shaped tiny smoke | `VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_f32_vulkan_tiny_synth/main.v` |
+| [vtl_opencl_vcl_support](./vtl_opencl_vcl_support) | OpenCL/VCL support notes | See example README |
+
+## Datasets and plotting
+
+| Example | What it shows |
+|---------|---------------|
+| [datasets_mnist](./datasets_mnist) | MNIST loader shape smoke |
+| [datasets_imdb](./datasets_imdb) | IMDB loader shape smoke |
+| [vtl_plot_scatter_colorscale](./vtl_plot_scatter_colorscale) | VTL tensor data feeding VSL plot |
+
+## Safe validation
+
+Prefer scoped commands:
+
+```bash
+VJOBS=1 v test vtl/nn/f32_training_smoke_test.v
+VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/f32_vulkan_training_smoke_d_vulkan_test.v
+```
+
+See [DEV_LIGHTWEIGHT.md](../docs/DEV_LIGHTWEIGHT.md) for the full safe command
+matrix.

--- a/examples/datasets_imdb/README.md
+++ b/examples/datasets_imdb/README.md
@@ -1,0 +1,21 @@
+# datasets_imdb
+
+Shape smoke for the IMDB sentiment-analysis dataset loader.
+
+## Run
+
+```bash
+v run vtl/examples/datasets_imdb/main.v
+```
+
+The loader returns:
+
+- `train_features`: `[25000]`
+- `test_features`: `[25000]`
+- `train_labels`: `[25000]`
+- `test_labels`: `[25000]`
+
+This example may download/cache dataset files depending on the local dataset
+state. For CI-safe training, prefer synthetic examples.
+
+See [datasets/README.md](../../datasets/README.md).

--- a/examples/datasets_mnist/README.md
+++ b/examples/datasets_mnist/README.md
@@ -1,0 +1,21 @@
+# datasets_mnist
+
+Shape smoke for the MNIST dataset loader.
+
+## Run
+
+```bash
+v run vtl/examples/datasets_mnist/main.v
+```
+
+The loader returns:
+
+- `train_features`: `[60000, 28, 28]`
+- `test_features`: `[10000, 28, 28]`
+- `train_labels`: `[60000]`
+- `test_labels`: `[10000]`
+
+This example may download/cache dataset files depending on the local dataset
+state. For CI-safe training, prefer synthetic CIFAR examples.
+
+See [datasets/README.md](../../datasets/README.md).

--- a/examples/nn_cifar10_f32_vulkan_tiny_synth/README.md
+++ b/examples/nn_cifar10_f32_vulkan_tiny_synth/README.md
@@ -1,6 +1,7 @@
 # nn_cifar10_f32_vulkan_tiny_synth
 
-f32 **training** smoke (forward, MSE, backprop, Adam). **Linear** forward/backward can use Vulkan GEMM.
+f32 **training** smoke (forward, MSE, backprop, Adam). Vulkan builds can use
+VSL GEMM and fused Adam where eligible.
 
 ## Run
 
@@ -15,8 +16,8 @@ VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_f32_vulkan_tiny_s
 ## Test
 
 ```bash
-VJOBS=1 v test vtl/nn/f32_vulkan_training_smoke_test.v
-VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 v -prod -d vulkan test vtl/nn/layers/linear_vulkan_gpu_d_vulkan_test.v
+VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/f32_vulkan_training_smoke_d_vulkan_test.v
+VTL_USE_VULKAN=1 VJOBS=1 v -prod -d vulkan test vtl/nn/optimizers/adam_f32_vulkan_d_vulkan_test.v
 ```
 
 CPU-only f32 training (no Vulkan SDK): `examples/nn_cifar10_f32_tiny_synth/`.

--- a/examples/nn_cifar10_vulkan/README.md
+++ b/examples/nn_cifar10_vulkan/README.md
@@ -1,6 +1,12 @@
 # nn_cifar10_vulkan
 
-CIFAR-shaped **f32** training smoke (`[3,8,8]` → Conv2D → ReLU → flatten → Linear → MSE). **Linear**, **Conv2D** (same-padding), and **ReLU** use Vulkan compute when opted in; Conv2D `d_input` stays CPU.
+CIFAR-shaped **f32** training smoke:
+
+`[3,8,8]` → Conv2D → ReLU → flatten → Linear → MSE.
+
+**Linear**, **Conv2D** (same-padding), **ReLU/Sigmoid**, and **Adam** use
+Vulkan compute when opted in; tensors remain CPU-backed for autograd
+compatibility.
 
 ## Run
 
@@ -8,7 +14,7 @@ CIFAR-shaped **f32** training smoke (`[3,8,8]` → Conv2D → ReLU → flatten �
 # CPU Linear (no Vulkan SDK required)
 v run vtl/examples/nn_cifar10_vulkan/main.v
 
-# GPU Linear via Vulkan (use -prod on V 0.5.1+ to avoid debug-instance crash)
+# GPU f32 stack via Vulkan (use -prod on V 0.5.1+ to avoid debug-instance crash)
 VTL_USE_VULKAN=1 v -prod -d vulkan run vtl/examples/nn_cifar10_vulkan/main.v
 ```
 

--- a/examples/vtl_plot_scatter_colorscale/README.md
+++ b/examples/vtl_plot_scatter_colorscale/README.md
@@ -1,0 +1,17 @@
+# vtl_plot_scatter_colorscale
+
+Small bridge example showing VTL tensor data feeding a VSL plot.
+
+## Run
+
+```bash
+v run vtl/examples/vtl_plot_scatter_colorscale/main.v
+```
+
+The example creates a 1-D tensor with `vtl.seq`, converts it to a V array, and
+uses `vsl.plot` to render a scatter plot with a custom color scale.
+
+## Related
+
+- [VTL first steps](../../docs/TUTORIAL_FIRST_STEPS.md)
+- [VSL plot docs](https://github.com/vlang/vsl/tree/main/plot)


### PR DESCRIPTION
## Summary
- Refresh README, docs landing page, tutorial path, device memory, lightweight dev docs, roadmap, datasets, and benchmarks for the ML release.
- Add examples catalog plus missing READMEs for dataset and plotting examples.
- Clarify CUDA/Vulkan release paths and safe commands.

## Test plan
- [x] `v check-md -hide-warnings` on changed VTL markdown files
- [x] stale-string sweep for old GPU/test references
- [x] `VJOBS=1 v test tests/core/creation_test.v nn/f32_training_smoke_test.v`
- [x] `VTL_USE_VULKAN=1 VTL_TEST_VULKAN=1 VJOBS=1 v -prod -d vulkan test nn/f32_vulkan_training_smoke_d_vulkan_test.v`


Made with [Cursor](https://cursor.com)