### PR TITLE
ci: split docs checks and refresh README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous Integration
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref_name == 'main' && github.sha || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
 on:
@@ -31,48 +31,6 @@ jobs:
     if: github.event_name == 'push'
     name: TODO
     uses: ./.github/workflows/todo.yml
-
-  validate-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout VTL
-        uses: actions/checkout@v4
-        with:
-          path: vtl
-
-      - name: Setup V
-        uses: vlang/setup-v@v1.4
-        with:
-          check-latest: true
-
-      - name: V doctor
-        run: v doctor
-
-      - name: Install dependencies
-        run: |
-          v install vsl && \
-          sudo apt-get -qq update && \
-          sudo apt-get -qq install \
-            gfortran \
-            libxi-dev \
-            libxcursor-dev \
-            mesa-common-dev \
-            liblapacke-dev \
-            libopenblas-dev \
-            libgc-dev \
-            libgl1-mesa-dev \
-            libopenmpi-dev \
-            libhdf5-dev \
-            hdf5-tools \
-            opencl-headers
-
-      - name: Copy VTL source code to V Modules
-        run: cp -rf ./vtl ~/.vmodules
-
-      - name: Validate Docs
-        run: |
-          cd ./vtl
-          v check-md .
 
   fmt-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,21 +1,30 @@
 name: Deploy Documentation
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
       - main
+    paths:
+      - '**.v'
+      - '**.md'
+      - '.github/workflows/deploy-docs.yml'
+  workflow_dispatch:
 
 jobs:
   deploy-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout vtl
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1
+        uses: vlang/setup-v@v1.4
         with:
           check-latest: true
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,69 @@
+name: Docs Check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - '**.md'
+      - '.github/workflows/docs-check.yml'
+  pull_request:
+    paths:
+      - '**.md'
+      - '.github/workflows/docs-check.yml'
+
+jobs:
+  check-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout VTL
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: vtl
+
+      - name: Setup V
+        uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
+
+      - name: Install VSL dependency
+        run: v install vsl
+
+      - name: Copy VTL source code to V Modules
+        run: cp -rf ./vtl ~/.vmodules/vtl
+
+      - name: Detect changed Markdown
+        id: markdown
+        run: |
+          cd vtl
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+
+          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ]; then
+            files="$(git ls-files '*.md')"
+          else
+            files="$(git diff --name-only --diff-filter=ACMR "${base}" HEAD -- '*.md')"
+          fi
+
+          {
+            echo 'files<<EOF'
+            echo "${files}"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate changed Markdown
+        if: steps.markdown.outputs.files != ''
+        run: |
+          cd ~/.vmodules/vtl
+          printf '%s\n' "${{ steps.markdown.outputs.files }}" | xargs v check-md -hide-warnings
+
+      - name: Skip when no Markdown changed
+        if: steps.markdown.outputs.files == ''
+        run: echo "No Markdown files changed."

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@
 
 [![Mentioned in Awesome V][awesomevbadge]][awesomevurl]
 [![CI][workflowbadge]][workflowurl]
+[![Docs][docsbadge]][docsurl]
+[![Full ML][fullmlbadge]][fullmlurl]
+[![Benchmarks][benchmarksbadge]][benchmarksurl]
 [![License: MIT][licensebadge]][licenseurl]
+![VSL Backed][vslbackedbadge]
+![CUDA Optional][cudaoptionalbadge]
+![Vulkan f32][vulkanbadge]
 
 **VTL** is a pure-[V](https://vlang.io) tensor library for numerical computing
 and machine learning — n-dimensional arrays, autograd, linear algebra via
@@ -165,7 +171,16 @@ Made with [contributors-img](https://contrib.rocks).
 
 [awesomevbadge]: https://awesome.re/mentioned-badge.svg
 [workflowbadge]: https://github.com/vlang/vtl/actions/workflows/ci.yml/badge.svg
+[docsbadge]: https://github.com/vlang/vtl/actions/workflows/deploy-docs.yml/badge.svg
+[fullmlbadge]: https://github.com/vlang/vtl/actions/workflows/ci-full-ml.yml/badge.svg
+[benchmarksbadge]: https://github.com/vlang/vtl/actions/workflows/benchmark-pr-comment.yml/badge.svg
 [licensebadge]: https://img.shields.io/badge/License-MIT-blue.svg
+[vslbackedbadge]: https://img.shields.io/badge/VSL-backed-027d9c?logo=v
+[cudaoptionalbadge]: https://img.shields.io/badge/CUDA-optional-76b900?logo=nvidia
+[vulkanbadge]: https://img.shields.io/badge/Vulkan-f32-ac162c?logo=vulkan
 [awesomevurl]: https://github.com/vlang/awesome-v/blob/master/README.md#scientific-computing
 [workflowurl]: https://github.com/vlang/vtl/actions/workflows/ci.yml
+[docsurl]: https://github.com/vlang/vtl/actions/workflows/deploy-docs.yml
+[fullmlurl]: https://github.com/vlang/vtl/actions/workflows/ci-full-ml.yml
+[benchmarksurl]: https://github.com/vlang/vtl/actions/workflows/benchmark-pr-comment.yml
 [licenseurl]: https://github.com/vlang/vtl/blob/main/LICENSE


### PR DESCRIPTION
## Summary
- Add Docs, Full ML, Benchmarks, VSL-backed, CUDA, and Vulkan badges to the README.
- Move Markdown validation into a dedicated docs-check workflow that validates changed Markdown only.
- Update docs deployment actions and simplify CI concurrency so stale main runs are canceled.

## Test plan
- `v check-md -hide-warnings README.md`
- `printf '%s\n' README.md | xargs v check-md -hide-warnings`
- YAML parse check for changed workflow files with Python/PyYAML
- Confirmed main branch has no required status checks, so skipped path-filtered workflows will not block PRs.


Made with [Cursor](https://cursor.com)