### PR TITLE
beta: prepare ML readiness gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,37 @@ jobs:
           fi
           # Default: scoped tests + tiny_synth smoke (see bin/test, issue #109)
           ~/.vmodules/vtl/bin/test ${{ matrix.flags }} $backend_flag
+
+  windows-smoke:
+    name: Windows tensor creation smoke
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout VTL
+        uses: actions/checkout@v4
+        with:
+          path: vtl
+
+      - name: Setup V
+        uses: vlang/setup-v@v1.4
+        with:
+          check-latest: true
+
+      - name: V doctor
+        run: v doctor
+
+      - name: Install VSL dependency
+        shell: bash
+        run: v install vsl
+
+      - name: Move VTL source code to V Modules
+        shell: bash
+        run: |
+          mkdir -p ~/.vmodules
+          mv ./vtl ~/.vmodules/vtl
+
+      - name: Run Windows creation regression
+        shell: bash
+        env:
+          VJOBS: '1'
+        run: v test ~/.vmodules/vtl/tests/core/creation_test.v

--- a/README.md
+++ b/README.md
@@ -52,11 +52,16 @@ t.get([1, 1])
 
 ## ML Release Highlights
 
+The ML beta scope is the high-level VTL API: tensors, autograd, layers, losses,
+optimizers, datasets, and CPU training. CUDA and Vulkan paths are available for
+opt-in validation and early adopters, but remain experimental backend
+accelerators rather than stable user contracts.
+
 | Area | Status |
 |------|--------|
 | f32 training | `Sequential` + MSE + Adam smoke tests |
-| CUDA | Linear/Conv2D forward, CUDA backward, GPU activation chain, Adam optimizer slots |
-| Vulkan | f32 Linear, Conv2D same-padding, ReLU/Sigmoid, fused Adam shader |
+| CUDA | Experimental opt-in Linear/Conv2D forward, CUDA backward, activation chain, Adam slots |
+| Vulkan | Experimental opt-in f32 Linear, Conv2D same-padding, ReLU/Sigmoid, fused Adam shader |
 | Datasets | MNIST, IMDB, CIFAR-10 loaders plus CI-safe synthetic examples |
 | Benchmarks | VTL vs NumPy/PyTorch scripts and PR benchmark workflow |
 
@@ -71,21 +76,22 @@ import vtl.nn.layers
 import vtl.nn.models
 import vtl.nn.optimizers
 
-mut ctx := autograd.ctx[f64]()
-mut model := models.sequential_from_ctx[f64](ctx)
+mut ctx := autograd.ctx[f32]()
+mut model := models.sequential_from_ctx[f32](ctx)
 model.input([784])
 model.linear(256)
 model.linear(10)
+model.mse_loss()
 
-input_tensor := vtl.zeros[f64]([64, 784])
+input_tensor := vtl.zeros[f32]([64, 784])
 mut x := ctx.variable(input_tensor)
 y_pred := model.forward(x)!
 
-target := vtl.zeros[f64]([64, 10])
+target := vtl.zeros[f32]([64, 10])
 mut loss_val := model.loss(y_pred, target)!
 loss_val.backprop()!
 
-mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
+mut opt := optimizers.adam_optimizer[f32](optimizers.AdamOptimizerConfig{
 	learning_rate: 0.001
 })
 opt.build_params(model.info.layers)

--- a/docs/ML_BETA_API_REVIEW.md
+++ b/docs/ML_BETA_API_REVIEW.md
@@ -35,7 +35,7 @@ through the beta unless a breaking change is explicitly approved:
 - `vtl.nn.loss`: MSE, BCE, cross-entropy, sigmoid/softmax cross-entropy, Huber,
   KL divergence, and NLL helpers.
 - `vtl.nn.optimizers`: Adam, AdamW, SGD, RMSProp, AdaGrad, schedulers, and
-  CPU/GPU Adam step helpers used by the training path.
+  CPU optimizer steps used by the f32 training path.
 - `vtl.datasets` and `vtl.nn.data`: loaders and dataloader utilities.
 - `vtl.storage`: CPU and optional backend storage abstractions used by tensors.
 
@@ -46,6 +46,7 @@ rather than stable end-user contracts:
 
 - CUDA/Vulkan hook functions in `nn/layers/*cuda*`, `nn/layers/*vulkan*`,
   `nn/gates/**`, `autograd_cuda/**`, `tensor_cuda_*`, and `tensor_vulkan_*`.
+- CUDA/Vulkan optimizer step helpers, including low-level Adam GPU parity paths.
 - Public fallback functions with names like `try_*`, `*_hooks_*`, `*_bind_*`, and
   `*_notd_*`.
 - Low-level storage constructors in `storage/cuda_*`, `storage/vcl_*`, and
@@ -79,8 +80,10 @@ high-level tensor/model APIs and environment/config flags.
 - `nn/internal/**` still has public functions. If V currently requires this for
   package boundaries, document them as internal support APIs and avoid tutorial
   references.
-- Optimizer examples should prefer `f32` for GPU-backed beta paths and explain
-  when CUDA uses `f64` vs Vulkan uses `f32`.
+- Optimizer and training examples should prefer `f32` for the beta path.
+  `f64` tensor math remains available, but generic `f64` autograd/training
+  should stay outside the stable beta contract until the generic `Gate[T]`
+  interface no longer specializes mixed `Payload[f32]`/`Payload[f64]` types.
 
 ### Breaking-Change Candidates
 
@@ -99,9 +102,14 @@ Do not change these without explicit approval:
 VTL is suitable for an ML beta if the public contract is described as:
 
 1. Stable: tensors, autograd, high-level layers/losses/optimizers/models,
-   datasets, and CPU training.
+   datasets, and f32 CPU training.
 2. Beta/experimental: CUDA and Vulkan acceleration hooks, low-level storage, and
    conditional backend dispatch.
 3. Internal support: `nn/internal/**` and backend-specific glue that remains
    public for compilation reasons.
+
+Windows, ARM GPU, persistent Vulkan activation chaining, and backend-specific
+performance work are tracked as validation or post-beta work. They should not be
+advertised as part of the stable beta contract until dedicated CI or hardware
+coverage proves them.
 

--- a/docs/ML_ROADMAP.md
+++ b/docs/ML_ROADMAP.md
@@ -31,14 +31,24 @@ GPU memory: [DEVICE_MEMORY.md](DEVICE_MEMORY.md)
 
 **VSL (downstream):** [#280](https://github.com/vlang/vsl/issues/280)–[#285](https://github.com/vlang/vsl/issues/285), [#304](https://github.com/vlang/vsl/pull/304) conv2d backward GEMM, [#305](https://github.com/vlang/vsl/pull/305) Adam shaders.
 
-## Critical path (open)
+## Beta gate (open)
 
 | Priority | Issue | Topic |
 |----------|-------|--------|
 | P1 | [#41](https://github.com/vlang/vtl/issues/41) | Windows example crash — shape clone landed; needs Windows CI confirmation |
+
+## Post-beta tracking
+
+| Priority | Issue | Topic |
+|----------|-------|--------|
 | P2 | [#63](https://github.com/vlang/vtl/issues/63) | ARM GPU support |
-| P2 | — | `v check-md -hide-warnings` on remaining docs (example READMEs done) |
 | P2 | — | Vulkan: persistent GPU activation chain between layers (CUDA has `VTL_GPU_ACTIVATIONS`) |
+
+The beta contract is tensors, autograd, high-level layers/losses/optimizers,
+datasets, and f32 CPU training. CUDA and Vulkan remain opt-in experimental
+backend paths during beta. Generic f64 training is tracked as post-beta until
+the autograd `Gate[T]` interface compiles without mixed `Payload[f32]` and
+`Payload[f64]` specialization.
 
 ## Local development
 
@@ -58,6 +68,7 @@ v run vtl/examples/nn_cifar10_f32_tiny_synth/main.v
 ## CI
 
 - **Default PR:** `bin/test` (scoped modules + `nn_cifar10_tiny_synth`)
+- **f32 beta smoke:** `nn_cifar10_f32_tiny_synth` and f32 autograd/training tests
 - **`full-ml` label:** `ci-full-ml.yml` runs `bin/test --full`
 - **CUDA / Vulkan:** local or future labeled workflows
 

--- a/docs/TUTORIAL_OPTIMIZERS.md
+++ b/docs/TUTORIAL_OPTIMIZERS.md
@@ -13,33 +13,28 @@ All optimizers also support learning rate schedulers — see the last section be
 ```v ignore
 import vtl
 import vtl.autograd
-import vtl.nn.layers
+import vtl.nn.models
 import vtl.nn.optimizers
-import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
+mut ctx := autograd.ctx[f32]()
+mut model := models.sequential_from_ctx[f32](ctx)
+model.input([784])
+model.linear(256)
+model.linear(10)
+model.mse_loss()
 
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
-
-mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
+mut opt := optimizers.adam_optimizer[f32](optimizers.AdamOptimizerConfig{
 	learning_rate: 0.001
 })
-opt.build_params(model)
+opt.build_params(model.info.layers)
 
 // Dummy data — replace with real training data
-input_vals := vtl.zeros[f64]([64, 784])
-target_vals := vtl.zeros[f64]([64, 10])
+input_vals := vtl.zeros[f32]([64, 784])
+target_vals := vtl.zeros[f32]([64, 10])
 
 mut x := ctx.variable(input_vals)
-for layer in model {
-	x = layer.forward(x)!
-}
-target := ctx.variable(target_vals)
-_ = target
-
-mut loss_val := model[1].forward(x)!
+pred := model.forward(x)!
+mut loss_val := model.loss(pred, target_vals)!
 loss_val.backprop()!
 opt.update()!
 ```
@@ -65,12 +60,12 @@ import vtl.nn.layers
 import vtl.nn.optimizers
 import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
+mut ctx := autograd.ctx[f32]()
+lin1 := layers.linear_layer[f32](ctx, 784, 256)
+lin2 := layers.linear_layer[f32](ctx, 256, 10)
+model := [types.Layer[f32](lin1), types.Layer[f32](lin2)]
 
-mut opt := optimizers.adamw[f64](optimizers.AdamWOptimizerConfig{
+mut opt := optimizers.adamw[f32](optimizers.AdamWOptimizerConfig{
 	learning_rate: 0.001
 	weight_decay:  0.01
 })
@@ -88,12 +83,12 @@ import vtl.nn.layers
 import vtl.nn.optimizers
 import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
+mut ctx := autograd.ctx[f32]()
+lin1 := layers.linear_layer[f32](ctx, 784, 256)
+lin2 := layers.linear_layer[f32](ctx, 256, 10)
+model := [types.Layer[f32](lin1), types.Layer[f32](lin2)]
 
-mut opt := optimizers.rmsprop[f64](optimizers.RMSPropOptimizerConfig{
+mut opt := optimizers.rmsprop[f32](optimizers.RMSPropOptimizerConfig{
 	learning_rate: 0.001
 	alpha:         0.99
 })
@@ -116,12 +111,12 @@ import vtl.nn.layers
 import vtl.nn.optimizers
 import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
+mut ctx := autograd.ctx[f32]()
+lin1 := layers.linear_layer[f32](ctx, 784, 256)
+lin2 := layers.linear_layer[f32](ctx, 256, 10)
+model := [types.Layer[f32](lin1), types.Layer[f32](lin2)]
 
-mut opt := optimizers.adagrad[f64](optimizers.AdaGradOptimizerConfig{
+mut opt := optimizers.adagrad[f32](optimizers.AdaGradOptimizerConfig{
 	learning_rate: 0.01
 })
 opt.build_params(model)
@@ -147,12 +142,12 @@ import vtl.nn.layers
 import vtl.nn.optimizers
 import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
+mut ctx := autograd.ctx[f32]()
+lin1 := layers.linear_layer[f32](ctx, 784, 256)
+lin2 := layers.linear_layer[f32](ctx, 256, 10)
+model := [types.Layer[f32](lin1), types.Layer[f32](lin2)]
 
-mut opt := optimizers.sgd[f64](optimizers.SgdOptimizerConfig{
+mut opt := optimizers.sgd[f32](optimizers.SgdOptimizerConfig{
 	learning_rate: 0.01
 })
 opt.build_params(model)
@@ -170,24 +165,24 @@ import vtl.nn.layers
 import vtl.nn.optimizers
 import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
-mut opt := optimizers.sgd[f64](optimizers.SgdOptimizerConfig{ learning_rate: 0.01 })
+mut ctx := autograd.ctx[f32]()
+lin1 := layers.linear_layer[f32](ctx, 784, 256)
+lin2 := layers.linear_layer[f32](ctx, 256, 10)
+model := [types.Layer[f32](lin1), types.Layer[f32](lin2)]
+mut opt := optimizers.sgd[f32](optimizers.SgdOptimizerConfig{ learning_rate: 0.01 })
 opt.build_params(model)
 
 // StepLR: reduce LR by gamma every step_size steps
-mut scheduler := optimizers.step_lr[f64](30, 0.1)
+mut scheduler := optimizers.step_lr[f32](30, 0.1)
 
 // ExponentialLR: multiply LR by gamma every step
-mut scheduler2 := optimizers.exponential_lr[f64](0.95)
+mut scheduler2 := optimizers.exponential_lr[f32](0.95)
 
 // CosineAnnealingLR: cosine decay from initial_lr to lrd
-mut scheduler3 := optimizers.cosine_annealing_lr[f64](100, 1e-5)
+mut scheduler3 := optimizers.cosine_annealing_lr[f32](100, 1e-5)
 
 // ReduceLROnPlateau: reduce when metric stops improving
-mut scheduler4 := optimizers.reduce_lr_on_plateau[f64](optimizers.ReduceLROnPlateauConfig{
+mut scheduler4 := optimizers.reduce_lr_on_plateau[f32](optimizers.ReduceLROnPlateauConfig{
 	patience: 10
 	factor:   0.1
 })
@@ -205,36 +200,32 @@ for step := 0; step < 100; step++ {
 ```v ignore
 import vtl
 import vtl.autograd
-import vtl.nn.layers
+import vtl.nn.models
 import vtl.nn.optimizers
-import vtl.nn.types
 
-mut ctx := autograd.ctx[f64]()
+mut ctx := autograd.ctx[f32]()
+mut model := models.sequential_from_ctx[f32](ctx)
+model.input([784])
+model.linear(256)
+model.linear(10)
+model.mse_loss()
 
-lin1 := layers.linear_layer[f64](ctx, 784, 256)
-lin2 := layers.linear_layer[f64](ctx, 256, 10)
-model := [types.Layer[f64](lin1), types.Layer[f64](lin2)]
-
-mut opt := optimizers.adam_optimizer[f64](optimizers.AdamOptimizerConfig{
+mut opt := optimizers.adam_optimizer[f32](optimizers.AdamOptimizerConfig{
 	learning_rate: 0.001
 })
-opt.build_params(model)
+opt.build_params(model.info.layers)
 
-mut scheduler := optimizers.step_lr[f64](30, 0.1)
+mut scheduler := optimizers.step_lr[f32](30, 0.1)
 
 for epoch := 0; epoch < 10; epoch++ {
 	// Replace with real data batches
-	input_batch := vtl.zeros[f64]([64, 784])
-	target_batch := vtl.zeros[f64]([64, 10])
+	input_batch := vtl.zeros[f32]([64, 784])
+	target_batch := vtl.zeros[f32]([64, 10])
 
 	mut x := ctx.variable(input_batch)
-	for layer in model {
-		x = layer.forward(x)!
-	}
-	target := ctx.variable(target_batch)
-	_ = target
-
-	x.backprop()!
+	pred := model.forward(x)!
+	mut loss_val := model.loss(pred, target_batch)!
+	loss_val.backprop()!
 	opt.update()!
 
 	current_lr := scheduler.next_lr(0.001, epoch)

--- a/nn/optimizers/adam_cuda_d_cuda_test.v
+++ b/nn/optimizers/adam_cuda_d_cuda_test.v
@@ -1,0 +1,62 @@
+module optimizers
+
+import math
+import os
+import vtl.autograd
+import vtl.autograd_cuda
+
+fn test_adam_step_cuda_matches_cpu_when_enabled() {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
+		return
+	}
+	grad := [1.0, 2.0, 0.5]
+	mut theta_cpu := [3.0, 4.0, 5.0]
+	mut m_cpu := [0.1, 0.2, 0.3]
+	mut v_cpu := [0.01, 0.02, 0.03]
+	mut theta_gpu := theta_cpu.clone()
+	mut m_gpu := m_cpu.clone()
+	mut v_gpu := v_cpu.clone()
+	p := AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.01
+		epsilon: 1e-8
+	}
+	mut c := autograd.ctx[f64]()
+	autograd_cuda.attach_context_session(mut c)
+	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
+	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
+	for i in 0 .. grad.len {
+		assert math.abs(theta_cpu[i] - theta_gpu[i]) < 1e-6
+		assert math.abs(m_cpu[i] - m_gpu[i]) < 1e-6
+		assert math.abs(v_cpu[i] - v_gpu[i]) < 1e-6
+	}
+}
+
+fn test_adam_step_persistent_gpu_second_step_matches_cpu() {
+	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
+		return
+	}
+	mut c := autograd.ctx[f64]()
+	autograd_cuda.attach_context_session(mut c)
+	grad := [0.5, -0.25]
+	p := AdamStepParams{
+		beta1:   0.9
+		beta2:   0.999
+		lr_t:    0.01
+		epsilon: 1e-8
+	}
+	mut th_cpu := [2.0, 3.0]
+	mut m_cpu := [0.0, 0.0]
+	mut v_cpu := [0.0, 0.0]
+	mut th_gpu := th_cpu.clone()
+	mut m_gpu := m_cpu.clone()
+	mut v_gpu := v_cpu.clone()
+	for _ in 0 .. 2 {
+		adam_step_f64_cpu(grad, mut th_cpu, mut m_cpu, mut v_cpu, p)
+		adam_step_f64(grad, mut th_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
+	}
+	for i in 0 .. grad.len {
+		assert math.abs(th_cpu[i] - th_gpu[i]) < 1e-5
+	}
+}

--- a/nn/optimizers/optimizer_test.v
+++ b/nn/optimizers/optimizer_test.v
@@ -1,10 +1,7 @@
 module optimizers
 
-import math
-import os
 import vtl
 import vtl.autograd
-import vtl.autograd_cuda
 
 fn ctx[T]() &autograd.Context[T] {
 	return autograd.ctx[T]()
@@ -17,9 +14,9 @@ fn make_var[T](c &autograd.Context[T], val f64) &autograd.Variable[T] {
 
 // SGD: param -= lr * grad
 fn test_sgd_update() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 5.0)
-	mut opt := sgd[f64](learning_rate: 0.1)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 5.0)
+	mut opt := sgd[f32](learning_rate: 0.1)
 	opt.params << p
 	p.grad.set_nth(0, 1.0)
 	opt.update()!
@@ -29,9 +26,9 @@ fn test_sgd_update() ! {
 }
 
 fn test_sgd_zeros_grad_after_update() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 2.0)
-	mut opt := sgd[f64](learning_rate: 0.5)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 2.0)
+	mut opt := sgd[f32](learning_rate: 0.5)
 	opt.params << p
 	p.grad.set_nth(0, 4.0)
 	opt.update()!
@@ -69,69 +66,13 @@ fn test_adam_step_f64_cpu() {
 	assert m[0] > 0.0
 }
 
-fn test_adam_step_cuda_matches_cpu_when_enabled() {
-	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
-		return
-	}
-	grad := [1.0, 2.0, 0.5]
-	mut theta_cpu := [3.0, 4.0, 5.0]
-	mut m_cpu := [0.1, 0.2, 0.3]
-	mut v_cpu := [0.01, 0.02, 0.03]
-	mut theta_gpu := theta_cpu.clone()
-	mut m_gpu := m_cpu.clone()
-	mut v_gpu := v_cpu.clone()
-	p := AdamStepParams{
-		beta1:   0.9
-		beta2:   0.999
-		lr_t:    0.01
-		epsilon: 1e-8
-	}
-	mut c := autograd.ctx[f64]()
-	autograd_cuda.attach_context_session(mut c)
-	adam_step_f64_cpu(grad, mut theta_cpu, mut m_cpu, mut v_cpu, p)
-	adam_step_f64(grad, mut theta_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
-	for i in 0 .. grad.len {
-		assert math.abs(theta_cpu[i] - theta_gpu[i]) < 1e-6
-		assert math.abs(m_cpu[i] - m_gpu[i]) < 1e-6
-		assert math.abs(v_cpu[i] - v_gpu[i]) < 1e-6
-	}
-}
-
-fn test_adam_step_persistent_gpu_second_step_matches_cpu() {
-	if os.getenv('VTL_TEST_CUDA') != '1' || os.getenv('VTL_CUDA_OPTIMIZER') != '1' {
-		return
-	}
-	mut c := autograd.ctx[f64]()
-	autograd_cuda.attach_context_session(mut c)
-	grad := [0.5, -0.25]
-	p := AdamStepParams{
-		beta1:   0.9
-		beta2:   0.999
-		lr_t:    0.01
-		epsilon: 1e-8
-	}
-	mut th_cpu := [2.0, 3.0]
-	mut m_cpu := [0.0, 0.0]
-	mut v_cpu := [0.0, 0.0]
-	mut th_gpu := th_cpu.clone()
-	mut m_gpu := m_cpu.clone()
-	mut v_gpu := v_cpu.clone()
-	for _ in 0 .. 2 {
-		adam_step_f64_cpu(grad, mut th_cpu, mut m_cpu, mut v_cpu, p)
-		adam_step_f64(grad, mut th_gpu, mut m_gpu, mut v_gpu, p, c.device_session, 0)
-	}
-	for i in 0 .. grad.len {
-		assert math.abs(th_cpu[i] - th_gpu[i]) < 1e-5
-	}
-}
-
 fn test_adam_update_moves_param() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 1.0)
-	mut opt := adam_optimizer[f64](learning_rate: 0.01)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 1.0)
+	mut opt := adam_optimizer[f32](learning_rate: 0.01)
 	opt.params << p
-	opt.first_moments << vtl.zeros_like[f64](p.grad)
-	opt.second_moments << vtl.zeros_like[f64](p.grad)
+	opt.first_moments << vtl.zeros_like[f32](p.grad)
+	opt.second_moments << vtl.zeros_like[f32](p.grad)
 	p.grad.set_nth(0, 1.0)
 	before := p.value.get_nth(0)
 	opt.update()!
@@ -140,12 +81,12 @@ fn test_adam_update_moves_param() ! {
 }
 
 fn test_adamw_update_moves_param() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 1.0)
-	mut opt := adamw[f64](learning_rate: 0.01)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 1.0)
+	mut opt := adamw[f32](learning_rate: 0.01)
 	opt.params << p
-	opt.first_moments << vtl.zeros_like[f64](p.grad)
-	opt.second_moments << vtl.zeros_like[f64](p.grad)
+	opt.first_moments << vtl.zeros_like[f32](p.grad)
+	opt.second_moments << vtl.zeros_like[f32](p.grad)
 	p.grad.set_nth(0, 1.0)
 	before := p.value.get_nth(0)
 	opt.update()!
@@ -154,11 +95,11 @@ fn test_adamw_update_moves_param() ! {
 }
 
 fn test_rmsprop_update_moves_param() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 1.0)
-	mut opt := rmsprop[f64](learning_rate: 0.01)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 1.0)
+	mut opt := rmsprop[f32](learning_rate: 0.01)
 	opt.params << p
-	opt.sq_avg << vtl.zeros_like[f64](p.grad)
+	opt.sq_avg << vtl.zeros_like[f32](p.grad)
 	p.grad.set_nth(0, 1.0)
 	before := p.value.get_nth(0)
 	opt.update()!
@@ -167,11 +108,11 @@ fn test_rmsprop_update_moves_param() ! {
 }
 
 fn test_adagrad_update_moves_param() ! {
-	c := ctx[f64]()
-	mut p := make_var[f64](c, 1.0)
-	mut opt := adagrad[f64](learning_rate: 0.1)
+	c := ctx[f32]()
+	mut p := make_var[f32](c, 1.0)
+	mut opt := adagrad[f32](learning_rate: 0.1)
 	opt.params << p
-	opt.accumulated_sq_grads << vtl.zeros_like[f64](p.grad)
+	opt.accumulated_sq_grads << vtl.zeros_like[f32](p.grad)
 	p.grad.set_nth(0, 1.0)
 	before := p.value.get_nth(0)
 	opt.update()!


### PR DESCRIPTION
## Summary
- Document the ML beta contract around f32 CPU training, high-level optimizers, and experimental CUDA/Vulkan backends.
- Add a targeted Windows tensor creation smoke for the #41 shape ownership regression.
- Keep CUDA Adam parity coverage in a CUDA-only test while making default optimizer tests f32 beta gates.

## Test plan
- `python3 tools/audit_public_docs.py --summary`
- `v check-md -hide-warnings README.md docs/TUTORIAL_OPTIMIZERS.md docs/ML_BETA_API_REVIEW.md docs/ML_ROADMAP.md docs/DEV_LIGHTWEIGHT.md`
- `VJOBS=1 v test tests/core/creation_test.v`
- `VJOBS=1 v test nn/f32_autograd_smoke_test.v nn/f32_training_smoke_test.v nn/optimizers/optimizer_test.v`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows test coverage for tensor creation operations
  * Introduced CUDA optimizer step validation tests

* **Documentation**
  * Updated ML Release Highlights with expanded beta scope description
  * Refined optimizer API stability guidance; f32 now the recommended stable training path
  * Updated all code examples and tutorials to use f32
  * Added beta roadmap tracking and post-beta guidance sections

* **Tests**
  * Updated optimizer tests to use f32; reorganized CUDA-specific tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->