### PR TITLE
ci: bump setup-v to v1.5

### DIFF
--- a/.github/workflows/benchmark-pr-comment.yml
+++ b/.github/workflows/benchmark-pr-comment.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           path: vtl
 
-      - uses: vlang/setup-v@v1.4
+      - uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 

--- a/.github/workflows/ci-full-ml.yml
+++ b/.github/workflows/ci-full-ml.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: vtl
 
-      - uses: vlang/setup-v@v1.4
+      - uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1
+        uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 
@@ -97,7 +97,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.4
+        uses: vlang/setup-v@v1.5.5
         with:
           check-latest: true
 
@@ -150,7 +150,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.4
+        uses: vlang/setup-v@v1.5.5
         with:
           check-latest: true
           stable: true

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.4
+        uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,7 +26,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.4
+        uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 


### PR DESCRIPTION
## Summary

- Bump all workflows to **`vlang/setup-v@v1.5`**.

## Why

[vlang/setup-v#17](https://github.com/vlang/setup-v/pull/17) merged and tagged as **v1.5**:
- Windows: `makev.bat -gcc` instead of GNU `make`
- `v.exe` detection and incomplete install dir recovery
- `stable: true` resolves latest release without requiring `check-latest`

## Test plan

- [ ] CI matrix (including `windows-latest` smoke) passes with `setup-v@v1.5`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to use updated versions of the V language toolchain setup action across multiple CI/CD pipeline jobs, including benchmark testing, full ML pipeline execution, standard tests, Windows smoke tests, documentation deployment, and documentation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->