### PR TITLE
fix(ci): correct setup-v tag v1.5.5 -> v1.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5.5
+        uses: vlang/setup-v@v1.5
         with:
           check-latest: true
 
@@ -150,7 +150,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5.5
+        uses: vlang/setup-v@v1.5
         with:
           check-latest: true
           stable: true


### PR DESCRIPTION
Fix typo from setup-v bump (invalid tag `v1.5.5`).

Made with [Cursor](https://cursor.com)