### PR TITLE
ci: bump setup-v to v1.6 for Windows bootstrap

### DIFF
--- a/.github/workflows/benchmark-pr-comment.yml
+++ b/.github/workflows/benchmark-pr-comment.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           path: vtl
 
-      - uses: vlang/setup-v@v1.5
+      - uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 

--- a/.github/workflows/ci-full-ml.yml
+++ b/.github/workflows/ci-full-ml.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           path: vtl
 
-      - uses: vlang/setup-v@v1.5
+      - uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5
+        uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 
@@ -97,7 +97,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5
+        uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 
@@ -150,10 +150,9 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5
+        uses: vlang/setup-v@v1.6
         with:
           check-latest: true
-          stable: true
 
       - name: V doctor
         run: v doctor

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -24,7 +24,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5
+        uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -26,7 +26,7 @@ jobs:
           path: vtl
 
       - name: Setup V
-        uses: vlang/setup-v@v1.5
+        uses: vlang/setup-v@v1.6
         with:
           check-latest: true
 


### PR DESCRIPTION
## Summary

- Bump all workflows to `vlang/setup-v@v1.6`.
- Windows smoke: `check-latest: true` only (drop `stable: true`).

## Why

- v1.6 invokes `.\makev.bat -gcc` correctly on Windows cmd.
- `stable: true` pulled tag 0.5.1 (no `makev.bat`), breaking bootstrap.

## Test plan

- [ ] Windows tensor creation smoke passes with setup-v@v1.6


Made with [Cursor](https://cursor.com)