### PR TITLE
chore: release v0.2.0-beta.1

### DIFF
--- a/v.mod
+++ b/v.mod
@@ -1,8 +1,8 @@
 Module {
-        name: 'vtl'
-        description: 'The V Tensor Library'
-        version: '0.2.0'
-        license: 'MIT'
+	name: 'vtl'
+	description: 'The V Tensor Library'
+	version: '0.2.0-beta.1'
+	license: 'MIT'
 	repo_url: 'https://github.com/vlang/vtl'
-        dependencies: ['vsl']
+	dependencies: ['vsl@0.2.0-beta.1']
 }


### PR DESCRIPTION
Bump v.mod for ML beta release v0.2.0-beta.1; pins vsl@0.2.0-beta.1.

Made with [Cursor](https://cursor.com)