### PR TITLE
fix(v.mod): use git tag ref for vsl beta dependency

### DIFF
--- a/v.mod
+++ b/v.mod
@@ -4,5 +4,5 @@ Module {
 	version: '0.2.0-beta.1'
 	license: 'MIT'
 	repo_url: 'https://github.com/vlang/vtl'
-	dependencies: ['vsl@0.2.0-beta.1']
+	dependencies: ['vsl@v0.2.0-beta.1']
 }


### PR DESCRIPTION
## Summary

- Fixes `dependencies` in `v.mod` so `v install` resolves VSL at the ML beta release.
- Changes `vsl@0.2.0-beta.1` → `vsl@v0.2.0-beta.1` to match the git tag created for [vsl v0.2.0-beta.1](https://github.com/vlang/vsl/releases/tag/v0.2.0-beta.1).

vpm passes the string after `@` to `git clone -b`; without the `v` prefix, install fails with `Remote branch 0.2.0-beta.1 not found`.

## Test plan

- [x] `cd vtl && v install` installs `vsl` at tag `v0.2.0-beta.1`
- [ ] CI green on merge (no functional code change)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `vsl` dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->