### PR TITLE
ci: use supported runners and pin VSL beta tag

### DIFF
--- a/.github/workflows/benchmark-pr-comment.yml
+++ b/.github/workflows/benchmark-pr-comment.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install deps
         run: |
-          v install vsl
+          v install vsl@v0.2.0-beta.1
           sudo apt-get update -qq
           sudo apt-get install -qq -y libopenblas-dev liblapacke-dev gfortran python3 python3-numpy
 

--- a/.github/workflows/ci-full-ml.yml
+++ b/.github/workflows/ci-full-ml.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          v install vsl
+          v install vsl@v0.2.0-beta.1
           sudo apt-get -qq update
           sudo apt-get -qq install \
             gfortran liblapacke-dev libopenblas-dev libgc-dev \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          v install vsl && \
+          v install vsl@v0.2.0-beta.1 && \
           sudo apt-get -qq update && \
           sudo apt-get -qq install \
             gfortran \
@@ -80,7 +80,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
         flags: ['', '--prod']
         backend: ['pure-v', 'cblas']
       fail-fast: false
@@ -124,7 +124,7 @@ jobs:
           else
             brew install coreutils hdf5 open-mpi openblas lapack opencl-headers
           fi
-          v install vsl
+          v install vsl@v0.2.0-beta.1
 
       - name: Move VTL source code to V Modules
         run: mv ./vtl ~/.vmodules
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install VSL dependency
         shell: bash
-        run: v install vsl
+        run: v install vsl@v0.2.0-beta.1
 
       - name: Move VTL source code to V Modules
         shell: bash

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -31,7 +31,7 @@ jobs:
           check-latest: true
 
       - name: Install VSL dependency
-        run: v install vsl
+        run: v install vsl@v0.2.0-beta.1
 
       - name: Copy VTL source code to V Modules
         run: cp -rf ./vtl ~/.vmodules/vtl


### PR DESCRIPTION
## Summary

- Replace retired `ubuntu-20.04` and `macos-12` with `ubuntu-22.04`, `ubuntu-24.04`, and `macos-14` so matrix jobs actually start (deprecated images were stuck queued for hours).
- Pin `v install vsl@v0.2.0-beta.1` across CI workflows to match `v.mod` and the VSL ML beta git tag.

## Test plan

- [ ] CI matrix completes without perpetual `queued` jobs on deprecated OS images
- [ ] `fmt-check`, Windows smoke, and `run-tests` install VSL at `v0.2.0-beta.1`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to pin VSL dependency to v0.2.0-beta.1, ensuring consistent dependency versions across build and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->